### PR TITLE
I've corrected the deployment configurations for GitHub Pages and Smi…

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: Adaptive Graph of Thoughts Documentation
 docs_dir: docs_src
-site_url: https://sapta-dey.github.io/Adaptive Graph of Thoughts-2.0/
-repo_url: https://github.com/sapta-dey/Adaptive Graph of Thoughts-2.0/
-repo_name: Adaptive Graph of Thoughts-2.0
+site_url: https://SaptaDey.github.io/Adaptive-Graph-of-Thoughts-MCP/
+repo_url: https://github.com/SaptaDey/Adaptive-Graph-of-Thoughts-MCP
+repo_name: Adaptive-Graph-of-Thoughts-MCP
 
 theme:
   name: material

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,4 +1,4 @@
 version: 1
 start:
-  command: ["python", "server.py"]
+  command: ["python", "src/adaptive_graph_of_thoughts/main.py"]
   port: 8000


### PR DESCRIPTION
…thery.

Specifically, I updated `mkdocs.yml` to use the correct repository name and URL formats, which should resolve potential pathing issues for GitHub Pages deployment. Here are the changes:
- I changed `site_url` to `https://SaptaDey.github.io/Adaptive-Graph-of-Thoughts-MCP/`
- I changed `repo_url` to `https://github.com/SaptaDey/Adaptive-Graph-of-Thoughts-MCP`
- I changed `repo_name` to `Adaptive-Graph-of-Thoughts-MCP`

I also updated `smithery.yaml` to point to the correct server startup script.
- I changed the `command` to `["python", "src/adaptive_graph_of_thoughts/main.py"]`