### PR TITLE
Fix: Correct package path in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,5 +88,5 @@ asyncio_mode = "auto"
 # python_files = "tests.py test_*.py *_tests.py"
 
 [[tool.poetry.packages]]
-include = "asr_got_reimagined"
+include = "adaptive_graph_of_thoughts"
 from = "src"


### PR DESCRIPTION
Changed tool.poetry.packages.include from 'asr_got_reimagined' to 'adaptive_graph_of_thoughts' to match the actual directory structure in src/. This resolves an issue where Poetry could not find the specified package during build or dependency resolution in CI/CD environments.