### PR TITLE
Fix: Improve Neo4j health check in production

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -53,7 +53,7 @@ services:
       NEO4J_dbms_memory_heap_initial__size: "512m" # Example: Set initial heap size
       NEO4J_dbms_memory_heap_max__size: "2G"      # Example: Set max heap size
     healthcheck:
-      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://localhost:7474 || exit 1"]
+      test: ["CMD-SHELL", "cypher-shell -u ${NEO4J_USER:-neo4j} -p ${NEO4J_PASSWORD} 'RETURN 1' || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
I changed the Neo4j health check in `docker-compose.prod.yml` to use `cypher-shell` instead of `wget`. This provides a more reliable way to determine if Neo4j is ready to accept connections.

The previous health check only verified if the Neo4j browser interface was accessible, which doesn't guarantee database readiness. The new health check executes a simple Cypher query, ensuring that the API service only starts after Neo4j is fully operational. This should prevent deployment failures caused by the API service attempting to connect to a non-ready Neo4j instance.