### PR TITLE
Fix: Correct CI test setup and dependencies

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -30,11 +30,14 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true # Recommended for CI caching
 
+      - name: Add src to PYTHONPATH
+        run: echo "PYTHONPATH=src" >> $GITHUB_ENV
+
       - name: Install dependencies
         run: poetry install --with dev --all-extras # Ensure all dependencies for tests are installed
 
       - name: Run tests with pytest
-        run: poetry run pytest --cov=src/asr_got_reimagined --cov-report=xml --cov-report=term-missing
+        run: poetry run pytest -vv --cov=src --cov-report=xml --cov-report=term-missing
         # Example: Add --cov options for coverage reporting
 
       # Optional: Upload coverage report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,8 @@ types-pyyaml = "^6.0.12.20250516"
 types-jsonschema = "^4.21.0.20250518" # Type hints for jsonschema
 mkdocs = "^1.6.0"  # Updated to a more recent version
 mkdocs-material = "^9.5.0" # Updated to a more recent version
+hypothesis = "^6.0"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This commit addresses several issues in the CI testing configuration:

1.  **Updated Dependencies**:
    - Added `hypothesis = "^6.0"` to `[tool.poetry.group.dev.dependencies]` in `pyproject.toml` as it is used in property-based tests.

2.  **GitHub Actions Workflow (`.github/workflows/ci-tests.yml`)**:
    - Added a step to explicitly add the `src` directory to `PYTHONPATH`. This ensures that modules within `src` are correctly resolved during tests, addressing `ModuleNotFoundError` issues.
    - Modified the `pytest` command to `poetry run pytest -vv --cov=src --cov-report=xml --cov-report=term-missing`. This adds verbose output (`-vv`) for better debugging and corrects the coverage path from `--cov=src/asr_got_reimagined` to `--cov=src`, ensuring accurate coverage reporting.

3.  **Syntax Errors**:
    - The issue mentioned a ` ``` ` syntax error in `src/adaptive_graph_of_thoughts/tests/test_stage_4_evidence.py`. A review of the file did not reveal this syntax error in its current state.

These changes should resolve the CI failures related to module import errors, missing dependencies, and incorrect test execution/coverage commands.