### PR TITLE
Fix: Remove duplicate dependencies from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,10 +60,6 @@ types-jsonschema = "^4.21.0.20250518" # Type hints for jsonschema
 
 types-pyyaml = "^6.0.12.20250516"
 
-mkdocs = "^1.6.0"  # Updated to a more recent version
-mkdocs-material = "^9.5.0" # Updated to a more recent version
-hypothesis = "^6.0"
-
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Removes duplicate entries for mkdocs, mkdocs-material, and hypothesis in the [tool.poetry.group.dev.dependencies] section of the pyproject.toml file.

This resolves a TOMLDecodeError that was causing job failures.