### PR TITLE
I tried to fix multiple syntax and import errors.

### DIFF
--- a/src/adaptive_graph_of_thoughts/domain/utils/math_helpers.py
+++ b/src/adaptive_graph_of_thoughts/domain/utils/math_helpers.py
@@ -2,8 +2,8 @@ from typing import Optional
 
 from loguru import logger
 
-from src.adaptive_graph_of_thoughts.domain.models.common import CertaintyScore, ConfidenceVector
-from src.adaptive_graph_of_thoughts.domain.models.graph_elements import (
+from adaptive_graph_of_thoughts.domain.models.common import CertaintyScore, ConfidenceVector
+from adaptive_graph_of_thoughts.domain.models.graph_elements import (
     EdgeType,
     StatisticalPower,
 )

--- a/src/adaptive_graph_of_thoughts/domain/utils/metadata_helpers.py
+++ b/src/adaptive_graph_of_thoughts/domain/utils/metadata_helpers.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 from loguru import logger
 
-# from src.adaptive_graph_of_thoughts.domain.models.graph_elements import FalsificationCriteria, BiasFlag # If needed
+# from adaptive_graph_of_thoughts.domain.models.graph_elements import FalsificationCriteria, BiasFlag # If needed
 
 
 def assess_falsifiability_score(

--- a/src/adaptive_graph_of_thoughts/tests/test_base_client.py
+++ b/src/adaptive_graph_of_thoughts/tests/test_base_client.py
@@ -5,7 +5,7 @@ import pytest
 import threading
 import time
 
-from adaptive_graph_of_thoughts.base_client import BaseClient, TimeoutError
+from adaptive_graph_of_thoughts.services.api_clients.base_client import BaseClient, TimeoutError
 
 class DummyTransport:
     def __init__(self, responses):

--- a/src/adaptive_graph_of_thoughts/tests/test_config.py
+++ b/src/adaptive_graph_of_thoughts/tests/test_config.py
@@ -1,7 +1,7 @@
 import pytest
 import yaml
 
-from adaptive_graph_of_thoughts.config import Config
+from adaptive_graph_of_thoughts.config import Settings
 
 def test_config_load_from_yaml(tmp_path):
     config_data = {"learning_rate": 0.01, "batch_size": 32, "max_steps": 1000}

--- a/src/adaptive_graph_of_thoughts/tests/test_graph_elements.py
+++ b/src/adaptive_graph_of_thoughts/tests/test_graph_elements.py
@@ -1,3 +1,5 @@
+import pytest
+
 @pytest.fixture
 def empty_graph():
     """Provide an empty Graph for testing."""

--- a/tests/unit/adaptive_graph_of_thoughts/domain/models/test_graph_elements.py
+++ b/tests/unit/adaptive_graph_of_thoughts/domain/models/test_graph_elements.py
@@ -4,8 +4,6 @@ import uuid
 from datetime import datetime
 from hypothesis import given, strategies as st
 
-from adaptive_graph_of_thoughts.domain.models.graph_elements import GraphElement
-
 # Hypothesis strategies for GraphElement parameters
 valid_uuid = st.uuids()
 short_label = st.text(min_size=0, max_size=50)


### PR DESCRIPTION
Here's what I did:
- I addressed a syntax error in `src/adaptive_graph_of_thoughts/domain/stages/stage_4_evidence.py` by replacing a complex Cypher query string with a placeholder ("test_query_syntax_fix") for diagnostic purposes. The original error was persistent and its nature shifted with different fix attempts, indicating a complex issue.
- I corrected unescaped markdown backticks in several test files (though later investigation suggested this might not have been the root cause for those files).
- I added a missing `import pytest` to `src/adaptive_graph_of_thoughts/tests/test_graph_elements.py`.
- I corrected the import path for `BaseClient` in `src/adaptive_graph_of_thoughts/tests/test_base_client.py` from `adaptive_graph_of_thoughts.base_client` to `adaptive_graph_of_thoughts.services.api_clients.base_client`.
- I changed the import from `Config` to `Settings` in `src/adaptive_graph_of_thoughts/tests/test_config.py` to align with `adaptive_graph_of_thoughts.config.py`.
- I removed an import for a non-existent `GraphElement` class in `tests/unit/adaptive_graph_of_thoughts/domain/models/test_graph_elements.py`.
- I corrected `src.` prefixes in import paths in `src/adaptive_graph_of_thoughts/domain/utils/math_helpers.py` and `metadata_helpers.py`.
- I attempted to install dependencies using `poetry install --with dev`.
- I attempted to gather all errors by running `python -m pytest --collect-only`, but this step repeatedly timed out.

Where I got stuck:
The primary blocker was the syntax error in `src/adaptive_graph_of_thoughts/domain/stages/stage_4_evidence.py` at line 409. The error message was initially "Invalid Python syntax" for a line within a triple-quoted string. My attempts to fix it (e.g., ensuring it's a valid string, changing to raw string, single-line string with newlines) led to different errors, such as `IndentationError` on other lines or "unterminated triple-quoted string literal" errors pointing to docstrings much later in the file. This made it difficult to isolate the root cause. My final diagnostic step was to replace the query string with a simple placeholder; however, I couldn't fully verify this change across the codebase via `pytest --collect-only` due to timeouts.

I need to run `pytest --collect-only` again to verify these fixes and identify any remaining import or syntax errors.