### PR TITLE
Update CI workflow to use Poetry

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,30 +1,60 @@
-name: Run Python Tests
+name: CI
 
 on:
   push:
-    branches:
-      - main
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
 
 jobs:
-  test:
+  tests:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.9'
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
 
-    - name: Set PYTHONPATH
-      run: echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pypoetry
+            .venv
+          key: ${{ runner.os }}-poetry-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-${{ matrix.python-version }}-
 
-    - name: Run tests
-      run: pytest --cov=.
+      - name: Install dependencies
+        run: poetry install --with dev
+
+      - name: Ruff Lint
+        if: matrix.python-version == '3.11'
+        run: poetry run ruff check .
+
+      - name: Ruff Format Check
+        if: matrix.python-version == '3.11'
+        run: poetry run ruff format --check .
+
+      - name: MyPy Type Check
+        if: matrix.python-version == '3.11'
+        run: poetry run mypy src/
+
+      - name: Pyright Type Check
+        if: matrix.python-version == '3.11'
+        run: poetry run pyright src/
+
+      - name: Run tests
+        run: poetry run pytest --cov=src


### PR DESCRIPTION
## Summary
- update CI to run on Python 3.11–3.13
- install dependencies via Poetry with cache
- run Ruff, MyPy, Pyright and pytest

## Testing
- `poetry run ruff check .`
- `poetry run ruff format --check .`
- `poetry run mypy src/`
- `poetry run pyright src/`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_685128f98d38832abfd4f12df88a1130