### PR TITLE
Add dashboard and setup improvements

### DIFF
--- a/src/adaptive_graph_of_thoughts/config.py
+++ b/src/adaptive_graph_of_thoughts/config.py
@@ -7,7 +7,7 @@ from threading import Lock
 from typing import Any, Optional, Union
 
 import yaml
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Thread safety lock
@@ -363,17 +363,12 @@ class RuntimeSettings(BaseSettings):
 
     app: AppSettingsModel = AppSettingsModel()
     neo4j: Neo4jSettingsModel = Neo4jSettingsModel()
-# at the top of src/adaptive_graph_of_thoughts/config.py, alongside your other imports
-from pydantic import Field
-
-…
-
--    asr_got: dict[str, Any] = field(default_factory=dict)
-+    asr_got: dict[str, Any] = Field(default_factory=dict)
+    asr_got: dict[str, Any] = Field(default_factory=dict)
 
     model_config = SettingsConfigDict(
         env_file=".env", env_nested_delimiter="__", extra="ignore"
     )
+
 
 
 def load_runtime_settings() -> RuntimeSettings:

--- a/src/adaptive_graph_of_thoughts/templates/dashboard.html
+++ b/src/adaptive_graph_of_thoughts/templates/dashboard.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>AGoT Dashboard</title>
+    <script src="https://unpkg.com/cytoscape/dist/cytoscape.min.js"></script>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        #graph { width: 60%; height: 400px; float: left; border: 1px solid #ccc; }
+        #properties { width: 35%; float: right; }
+        #chat-panel, #config-editor { clear: both; margin-top: 20px; }
+        textarea { width: 100%; }
+    </style>
+</head>
+<body>
+<h1>Adaptive Graph of Thoughts Dashboard</h1>
+<div id="graph"></div>
+<table id="properties"></table>
+<div id="chat-panel">
+    <h2>LLM Chat</h2>
+    <textarea id="chat-input" rows="4"></textarea>
+    <button onclick="sendQuestion()">Send</button>
+    <pre id="chat-response"></pre>
+</div>
+<div id="config-editor">
+    <h2>Configuration</h2>
+    <textarea id="yaml-config" rows="10">{{ config_yaml }}</textarea>
+    <button onclick="saveConfig()">Apply & Restart</button>
+    <pre id="config-message"></pre>
+</div>
+<script>
+function sendQuestion(){
+    fetch('/chat', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({question: document.getElementById('chat-input').value})})
+    .then(r=>r.json()).then(d=>{document.getElementById('chat-response').textContent=d.answer||d.message});
+}
+function saveConfig(){
+    fetch('/dashboard/save_config', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({yaml: document.getElementById('yaml-config').value})})
+    .then(r=>r.json()).then(d=>{document.getElementById('config-message').textContent=d.message});
+}
+</script>
+</body>
+</html>

--- a/src/adaptive_graph_of_thoughts/templates/setup_neo4j.html
+++ b/src/adaptive_graph_of_thoughts/templates/setup_neo4j.html
@@ -20,5 +20,8 @@
     <label>Database <input name="database" value="{{ values.database }}" required></label><br>
     <button type="submit">Save & Continue</button>
   </form>
+  {% if missing_deps %}
+  <p style="color: orange;">Missing optional packages: {{ missing_deps|join(', ') }}. Install them for full functionality.</p>
+  {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add optional .env import and dependency check in CLI setup
- secure web routes with optional Basic Auth
- show missing deps on setup screen
- provide new `/dashboard` UI for graph, chat, and config editing
- wire up minimal LLM helper and config save logic

## Testing
- `poetry run pytest -q` *(fails: test_mcp_endpoints::test_get_endpoint, test_delete_endpoint)*

------
https://chatgpt.com/codex/tasks/task_e_685352607dd4832a9fa22439eb400372