### PR TITLE
Fix NLQ input handling

### DIFF
--- a/src/adaptive_graph_of_thoughts/api/routes/nlq.py
+++ b/src/adaptive_graph_of_thoughts/api/routes/nlq.py
@@ -3,15 +3,28 @@ from __future__ import annotations
 import asyncio
 import json
 from collections.abc import AsyncGenerator
+import logging
+import re
 from typing import Dict
 
 from fastapi import APIRouter, Body
 from fastapi.responses import StreamingResponse
 
+from ..schemas import NLQPayload
 from ...domain.services.neo4j_utils import execute_query
 from ...services.llm import LLM_QUERY_LOGS, ask_llm
 
+logger = logging.getLogger(__name__)
+
 nlq_router = APIRouter()
+
+
+def _sanitize_question(question: str) -> str:
+    """Sanitize user provided question to reduce prompt injection risks."""
+    cleaned = question.replace("\r", " ").replace("\n", " ").strip()
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    # Truncate to a reasonable length
+    return cleaned[:2000]
 
 
 def _log_query(prompt: str, response: str) -> None:
@@ -25,7 +38,7 @@ def _log_query(prompt: str, response: str) -> None:
 
 
 @nlq_router.post("/nlq")
-async def nlq_endpoint(payload: Dict[str, str] = Body(...)) -> StreamingResponse:
+async def nlq_endpoint(payload: NLQPayload = Body(...)) -> StreamingResponse:
     """
     Handles POST requests to the /nlq endpoint, translating a natural language question into a Cypher query, executing it, and streaming the Cypher query, results, and a concise summary as a JSON response.
     
@@ -35,7 +48,7 @@ async def nlq_endpoint(payload: Dict[str, str] = Body(...)) -> StreamingResponse
     Returns:
         StreamingResponse: Streams JSON objects for the generated Cypher query, query results, and a summary answer.
     """
-    question = payload.get("question", "")
+    question = _sanitize_question(payload.question)
     cypher_prompt = f"Translate the question to a Cypher query: {question}"
     cypher = await asyncio.to_thread(ask_llm, cypher_prompt)
     _log_query(cypher_prompt, cypher)
@@ -48,13 +61,6 @@ async def nlq_endpoint(payload: Dict[str, str] = Body(...)) -> StreamingResponse
             bytes: JSON-encoded Cypher query and query results, each separated by a newline.
         """
         yield json.dumps({"cypher": cypher}).encode() + b"\n"
-        try:
-            records = await execute_query(cypher)
-            rows = [dict(r) for r in records]
-import logging
-
-logger = logging.getLogger(__name__)
-
         try:
             records = await execute_query(cypher)
             rows = [dict(r) for r in records]

--- a/src/adaptive_graph_of_thoughts/api/schemas.py
+++ b/src/adaptive_graph_of_thoughts/api/schemas.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any, Generic, Literal, Optional, TypeVar, Union
 
 from pydantic import BaseModel, Field, validator
@@ -5,6 +6,18 @@ from pydantic import BaseModel, Field, validator
 # --- Generic JSON-RPC Models ---
 T = TypeVar("T")
 E = TypeVar("E")  # Error data type
+
+
+class NLQPayload(BaseModel):
+    """Schema for natural language query requests."""
+
+    question: str = Field(..., description="Natural language question", max_length=2000)
+
+    @validator("question", pre=True)
+    def sanitize_question(cls, v: str) -> str:  # type: ignore[override]
+        cleaned = v.replace("\r", " ").replace("\n", " ").strip()
+        cleaned = re.sub(r"\s+", " ", cleaned)
+        return cleaned
 
 
 class JSONRPCRequest(BaseModel, Generic[T]):

--- a/src/adaptive_graph_of_thoughts/services/llm.py
+++ b/src/adaptive_graph_of_thoughts/services/llm.py
@@ -33,8 +33,6 @@ def ask_llm(prompt: str) -> str:
             result = resp.content[0].text
         else:
             import openai  # type: ignore
-        else:
-            import openai  # type: ignore
             client = openai.OpenAI(api_key=env_settings.openai_api_key)
             resp = client.chat.completions.create(
                 model=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"),


### PR DESCRIPTION
## Summary
- validate and sanitize NLQ questions
- fix duplicated logic in `nlq.py`
- clean up LLM service provider check

## Testing
- `make lint` *(fails: 698 errors)*
- `make check-types` *(fails: MyPy reported module name collision)*
- `make test` *(fails: 6 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68557c91b0ac832aa62e7401f6b2aa60