### PR TITLE
Secure NLQ and graph endpoints

### DIFF
--- a/src/adaptive_graph_of_thoughts/api/routes/explorer.py
+++ b/src/adaptive_graph_of_thoughts/api/routes/explorer.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from ...domain.services.neo4j_utils import execute_query
+from .mcp import verify_token
 
 explorer_router = APIRouter()
 
 
-@explorer_router.get("/graph")
+@explorer_router.get("/graph", dependencies=[Depends(verify_token)])
 async def graph_explorer_json(limit: int = 50):
     """
     Retrieve a list of nodes and edges from the Neo4j database for use in a graph explorer dashboard.

--- a/src/adaptive_graph_of_thoughts/api/routes/nlq.py
+++ b/src/adaptive_graph_of_thoughts/api/routes/nlq.py
@@ -5,11 +5,12 @@ import json
 from collections.abc import AsyncGenerator
 from typing import Dict
 
-from fastapi import APIRouter, Body
+from fastapi import APIRouter, Body, Depends
 from fastapi.responses import StreamingResponse
 
 from ...domain.services.neo4j_utils import execute_query
 from ...services.llm import LLM_QUERY_LOGS, ask_llm
+from .mcp import verify_token
 
 nlq_router = APIRouter()
 
@@ -24,7 +25,7 @@ def _log_query(prompt: str, response: str) -> None:
         LLM_QUERY_LOGS.pop(0)
 
 
-@nlq_router.post("/nlq")
+@nlq_router.post("/nlq", dependencies=[Depends(verify_token)])
 async def nlq_endpoint(payload: Dict[str, str] = Body(...)) -> StreamingResponse:
     """
     Handles POST requests to the /nlq endpoint, translating a natural language question into a Cypher query, executing it, and streaming the Cypher query, results, and a concise summary as a JSON response.


### PR DESCRIPTION
## Summary
- enforce token verification on `/nlq` and `/graph` endpoints

## Testing
- `pytest tests/unit/api/test_nlq.py::test_nlq_endpoint_basic_functionality -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68557d6c3d58832aa643b4b2547f7ab8