### PR TITLE
Improve EvidenceStage error handling

### DIFF
--- a/src/adaptive_graph_of_thoughts/domain/services/got_processor.py
+++ b/src/adaptive_graph_of_thoughts/domain/services/got_processor.py
@@ -13,6 +13,7 @@ from ..models.common_types import (
 # Import the import_stages function for lazy loading
 from ..stages import import_stages
 from ..stages.base_stage import BaseStage, StageOutput
+from ..stages.exceptions import StageInitializationError
 
 
 class GoTProcessor:
@@ -79,6 +80,13 @@ class GoTProcessor:
                     )
                     raise RuntimeError(
                         f"Failed to load class for stage: {stage_config.name} ({class_name} from {module_name})"
+                    ) from e
+                except StageInitializationError as e:
+                    logger.error(
+                        f"Initialization of stage '{stage_config.name}' failed: {e}"
+                    )
+                    raise RuntimeError(
+                        f"Stage initialization failed: {stage_config.name}"
                     ) from e
                 except Exception as e:
                     logger.error(

--- a/src/adaptive_graph_of_thoughts/domain/stages/__init__.py
+++ b/src/adaptive_graph_of_thoughts/domain/stages/__init__.py
@@ -1,5 +1,6 @@
 # Makes 'stages' a sub-package.
 from .base_stage import BaseStage, StageOutput
+from .exceptions import StageInitializationError
 
 
 # Import stage classes using a function to prevent circular imports
@@ -29,5 +30,6 @@ def import_stages():
 __all__ = [
     "BaseStage",
     "StageOutput",
+    "StageInitializationError",
     "import_stages",
 ]

--- a/src/adaptive_graph_of_thoughts/domain/stages/exceptions.py
+++ b/src/adaptive_graph_of_thoughts/domain/stages/exceptions.py
@@ -1,0 +1,7 @@
+class StageError(Exception):
+    """Base class for stage-related errors."""
+
+
+class StageInitializationError(StageError):
+    """Raised when a stage fails to initialize required resources."""
+

--- a/src/adaptive_graph_of_thoughts/domain/stages/stage_4_evidence.py
+++ b/src/adaptive_graph_of_thoughts/domain/stages/stage_4_evidence.py
@@ -7,13 +7,20 @@ from typing import Any, Optional
 from loguru import logger  # type: ignore
 
 from ...config import LegacyConfig
-from ...services.api_clients.exa_search_client import ExaSearchClient
+from ...services.api_clients.exa_search_client import (
+    ExaSearchClient,
+    ExaSearchClientError,
+)
 from ...services.api_clients.google_scholar_client import (
     GoogleScholarClient,
+    GoogleScholarClientError,
 )
 
 # Import API Clients and their data models
-from ...services.api_clients.pubmed_client import PubMedClient
+from ...services.api_clients.pubmed_client import (
+    PubMedClient,
+    PubMedClientError,
+)
 from ..models.common import (
     ConfidenceVector,
     EpistemicStatus,
@@ -42,6 +49,7 @@ from ..utils.neo4j_helpers import (
     prepare_node_properties_for_neo4j,
 )
 from .base_stage import BaseStage, StageOutput
+from .exceptions import StageInitializationError
 from .stage_3_hypothesis import HypothesisStage  # To access hypothesis_node_ids
 
 
@@ -59,13 +67,16 @@ class EvidenceStage(BaseStage):
         )
 
         # Initialize API Clients
+        failures: list[str] = []
+
         self.pubmed_client: Optional[PubMedClient] = None
         if settings.pubmed and settings.pubmed.base_url:
             try:
                 self.pubmed_client = PubMedClient(settings)
                 logger.info("PubMed client initialized for EvidenceStage.")
-            except Exception as e:
+            except PubMedClientError as e:
                 logger.error(f"Failed to initialize PubMedClient: {e}")
+                failures.append("PubMed")
         else:
             logger.warning(
                 "PubMed client not initialized for EvidenceStage: PubMed configuration missing or incomplete."
@@ -80,8 +91,9 @@ class EvidenceStage(BaseStage):
             try:
                 self.google_scholar_client = GoogleScholarClient(settings)
                 logger.info("Google Scholar client initialized for EvidenceStage.")
-            except Exception as e:
+            except GoogleScholarClientError as e:
                 logger.error(f"Failed to initialize GoogleScholarClient: {e}")
+                failures.append("GoogleScholar")
         else:
             logger.warning(
                 "Google Scholar client not initialized for EvidenceStage: Google Scholar configuration missing or incomplete (requires api_key and base_url)."
@@ -96,11 +108,17 @@ class EvidenceStage(BaseStage):
             try:
                 self.exa_client = ExaSearchClient(settings)
                 logger.info("Exa Search client initialized for EvidenceStage.")
-            except Exception as e:
+            except ExaSearchClientError as e:
                 logger.error(f"Failed to initialize ExaSearchClient: {e}")
+                failures.append("ExaSearch")
         else:
             logger.warning(
                 "Exa Search client not initialized for EvidenceStage: Exa Search configuration missing or incomplete (requires api_key and base_url)."
+            )
+
+        if not any([self.pubmed_client, self.google_scholar_client, self.exa_client]):
+            raise StageInitializationError(
+                "No evidence sources available. Failed to initialize: " + ", ".join(failures)
             )
 
     async def close_clients(self):
@@ -134,7 +152,7 @@ class EvidenceStage(BaseStage):
             return set(raw)
         try:
             return set(json.loads(raw))
-        except Exception:
+        except json.JSONDecodeError:
             logger.warning("Could not deserialize tags payload '%s'", raw)
             return set()
 


### PR DESCRIPTION
## Summary
- define StageInitializationError
- export StageInitializationError through stages package
- fail EvidenceStage initialization when no API clients are available
- catch StageInitializationError during stage loading
- tighten JSON decode error handling in EvidenceStage

## Testing
- `make test` *(fails: 11 errors during collection)*
- `make lint` *(fails to parse files)*
- `make check-types` *(fails with mypy syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68557cb1707c832a97122b344f469afa