### PR TITLE
Implement schema validation for settings

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -118,7 +118,8 @@ asr_got:
 
 # Configuration for Model Context Protocol (MCP) Server behavior
 mcp_settings:
-  protocol_version: "2024-11-05" # As per original claude_desktop_config.json  server_name: "Adaptive Graph of Thoughts MCP Server"
+  protocol_version: "2024-11-05" # As per original claude_desktop_config.json
+  server_name: "Adaptive Graph of Thoughts MCP Server"
   server_version: "0.1.0" # Match app.version
   vendor_name: "Adaptive Graph of Thoughts Development Team"
   # display_name: "Adaptive Graph of Thoughts" # If needed by MCP client

--- a/tests/unit/config/test_config_validation.py
+++ b/tests/unit/config/test_config_validation.py
@@ -1,26 +1,26 @@
+import copy
 import stat
+from pathlib import Path
 
 import pytest
 import yaml
 
 from adaptive_graph_of_thoughts.config import validate_config_schema
 
-# ConfigValidationError is replaced by ValueError from jsonschema,
-# which is raised by validate_config_schema.
-# No specific import needed for ValueError.
+BASE_CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "settings.yaml"
 
 
 @pytest.fixture
-def valid_config(tmp_path):
-    cfg = {
-        "host": "localhost",
-        "port": 8080,
-        "debug": True,
-        "databases": ["db1", "db2"],
-    }
-    file_path = tmp_path / "config.yaml"
-    file_path.write_text(yaml.safe_dump(cfg))
-    return file_path, cfg
+def base_config_dict() -> dict:
+    with open(BASE_CONFIG_PATH) as fh:
+        return yaml.safe_load(fh)
+
+
+@pytest.fixture
+def valid_config(tmp_path, base_config_dict):
+    file_path = tmp_path / "settings.yaml"
+    file_path.write_text(yaml.safe_dump(base_config_dict))
+    return file_path, copy.deepcopy(base_config_dict)
 
 
 def test_valid_config(valid_config):
@@ -36,8 +36,12 @@ def test_valid_config(valid_config):
 
 
 @pytest.fixture
-def minimal_config(tmp_path):
-    cfg = {"host": "127.0.0.1", "port": 1}
+def minimal_config(tmp_path, base_config_dict):
+    cfg = copy.deepcopy(base_config_dict)
+    cfg.pop("google_scholar", None)
+    cfg.pop("pubmed", None)
+    cfg.pop("exa_search", None)
+    cfg.pop("knowledge_domains", None)
     file_path = tmp_path / "config_min.yaml"
     file_path.write_text(yaml.safe_dump(cfg))
     return file_path, cfg
@@ -50,53 +54,40 @@ def test_minimal_config(minimal_config):
         config_data_to_validate = yaml.safe_load(f)
 
     assert validate_config_schema(config_data_to_validate) is True
-    # Optional fields are not defaulted by validate_config_schema,
-    # they are handled by Pydantic models when Settings() is created.
-    # This test might need to be re-evaluated based on what validate_config_schema
-    # is supposed to guarantee for minimal configs according to the schema.
-    # For now, we just check if it validates and the content matches the input.
-    assert config_data_to_validate["host"] == expected_config_data["host"]
-    assert config_data_to_validate["port"] == expected_config_data["port"]
-    # Default value checks like debug and databases are not applicable here
-    # as validate_config_schema only validates structure, not default filling.
+    assert "google_scholar" not in config_data_to_validate
 
 
-@pytest.mark.parametrize("missing_key", ["host", "port"])
-def test_missing_keys(tmp_path, missing_key):
-    cfg = {"host": "localhost", "port": 8080}
+@pytest.mark.parametrize("missing_key", ["app", "asr_got", "mcp_settings"])
+def test_missing_keys(tmp_path, base_config_dict, missing_key):
+    cfg = copy.deepcopy(base_config_dict)
     cfg.pop(missing_key)
     file_path = tmp_path / "config_missing.yaml"
     file_path.write_text(yaml.safe_dump(cfg))
     with open(file_path) as f:
         config_data_to_validate = yaml.safe_load(f)
-    with pytest.raises(ValueError) as exc:  # Changed from ConfigValidationError
+    with pytest.raises(ValueError) as exc:
         validate_config_schema(config_data_to_validate)
-    # The error message from jsonschema.validate might be more specific
-    # Example: "''host' is a required property'"
-    # We can check if the missing key is mentioned in the error.
-    assert missing_key in str(exc.value).lower()  # Making assert less brittle
+    assert missing_key in str(exc.value)
 
 
 @pytest.mark.parametrize(
     "field,value",
     [
-        ("host", 123),
-        ("port", "not_an_int"),
-        ("debug", "yes"),
-        ("databases", "not_a_list"),
+        ("app.port", "not_an_int"),
+        ("mcp_settings.protocol_version", 123),
     ],
 )
 def test_wrong_types(tmp_path, field, value):
-    cfg = {"host": "localhost", "port": 8080}
-    cfg[field] = value
+    cfg = copy.deepcopy(base_config_dict)
+    section, key = field.split(".")
+    cfg[section][key] = value
     file_path = tmp_path / "config_bad_type.yaml"
     file_path.write_text(yaml.safe_dump(cfg))
     with open(file_path) as f:
         config_data_to_validate = yaml.safe_load(f)
-    with pytest.raises(ValueError) as exc:  # Changed from ConfigValidationError
+    with pytest.raises(ValueError) as exc:
         validate_config_schema(config_data_to_validate)
-    # Check if the field causing the type error is mentioned.
-    assert field in str(exc.value).lower()  # Making assert less brittle
+    assert key in str(exc.value)
 
 
 def test_empty_file(tmp_path):
@@ -131,10 +122,11 @@ def test_unreadable_file(tmp_path):
 
 @pytest.mark.parametrize("port", [1, 65535])
 def test_boundary_values(tmp_path, port):
-    cfg = {"host": "localhost", "port": port}
+    cfg = copy.deepcopy(base_config_dict)
+    cfg["app"]["port"] = port
     file_path = tmp_path / f"config_port_{port}.yaml"
     file_path.write_text(yaml.safe_dump(cfg))
     with open(file_path) as f:
         config_data_to_validate = yaml.safe_load(f)
     assert validate_config_schema(config_data_to_validate) is True
-    assert config_data_to_validate["port"] == port
+    assert config_data_to_validate["app"]["port"] == port

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -42,14 +42,12 @@ from config import (
     validate_max_steps,
 )
 
+
 @pytest.fixture
 def sample_config_data():
     """Sample configuration data for testing."""
-    return {
-        "learning_rate": 0.01,
-        "batch_size": 32,
-        "max_steps": 1000
-    }
+    return {"learning_rate": 0.01, "batch_size": 32, "max_steps": 1000}
+
 
 @pytest.fixture
 def sample_yaml_content():
@@ -60,53 +58,45 @@ batch_size: 64
 max_steps: 2000
 """
 
+
 @pytest.fixture
 def sample_json_content():
     """Sample JSON configuration content."""
-    return {
-        "learning_rate": 0.03,
-        "batch_size": 128,
-        "max_steps": 3000
-    }
+    return {"learning_rate": 0.03, "batch_size": 128, "max_steps": 3000}
+
 
 @pytest.fixture
 def temp_config_file():
     """Create a temporary configuration file."""
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
-        yaml.dump({
-            "learning_rate": 0.01,
-            "batch_size": 32,
-            "max_steps": 1000
-        }, f)
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        yaml.dump({"learning_rate": 0.01, "batch_size": 32, "max_steps": 1000}, f)
         temp_path = f.name
     yield temp_path
     if os.path.exists(temp_path):
         os.unlink(temp_path)
+
 
 @pytest.fixture
 def temp_json_file():
     """Create a temporary JSON configuration file."""
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
-        json.dump({
-            "learning_rate": 0.01,
-            "batch_size": 32,
-            "max_steps": 1000
-        }, f)
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump({"learning_rate": 0.01, "batch_size": 32, "max_steps": 1000}, f)
         temp_path = f.name
     yield temp_path
     if os.path.exists(temp_path):
         os.unlink(temp_path)
 
+
 class TestValidationFunctions:
     """Test configuration validation functions."""
-    
+
     def test_validate_learning_rate_valid(self):
         """Test valid learning rates pass validation."""
         validate_learning_rate(0.01)
         validate_learning_rate(0.5)
         validate_learning_rate(1.0)
         validate_learning_rate(0.001)
-    
+
     def test_validate_learning_rate_invalid(self):
         """Test invalid learning rates raise ValueError."""
         with pytest.raises(ValueError, match="Learning rate must be between 0 and 1.0"):
@@ -117,13 +107,13 @@ class TestValidationFunctions:
             validate_learning_rate(1.1)
         with pytest.raises(ValueError, match="Learning rate must be between 0 and 1.0"):
             validate_learning_rate("0.1")
-    
+
     def test_validate_batch_size_valid(self):
         """Test valid batch sizes pass validation."""
         validate_batch_size(1)
         validate_batch_size(32)
         validate_batch_size(1000)
-    
+
     def test_validate_batch_size_invalid(self):
         """Test invalid batch sizes raise ValueError."""
         with pytest.raises(ValueError, match="Batch size must be a positive integer"):
@@ -134,13 +124,13 @@ class TestValidationFunctions:
             validate_batch_size(1.5)
         with pytest.raises(ValueError, match="Batch size must be a positive integer"):
             validate_batch_size("32")
-    
+
     def test_validate_max_steps_valid(self):
         """Test valid max steps pass validation."""
         validate_max_steps(1)
         validate_max_steps(1000)
         validate_max_steps(10000)
-    
+
     def test_validate_max_steps_invalid(self):
         """Test invalid max steps raise ValueError."""
         with pytest.raises(ValueError, match="Max steps must be a positive integer"):
@@ -151,48 +141,64 @@ class TestValidationFunctions:
             validate_max_steps(1.5)
         with pytest.raises(ValueError, match="Max steps must be a positive integer"):
             validate_max_steps("1000")
-    
+
     def test_validate_config_schema(self):
         """Test config schema validation."""
-        assert validate_config_schema({"key": "value"}) is True
-        assert validate_config_schema({}) is True
+        valid = {
+            "app": {"host": "localhost", "port": 8000},
+            "asr_got": runtime_settings.asr_got,
+            "mcp_settings": {
+                "protocol_version": "1",
+                "server_name": "srv",
+                "server_version": "0.1",
+                "vendor_name": "v",
+            },
+        }
+        assert validate_config_schema(valid) is True
+        with pytest.raises(ValueError):
+            validate_config_schema({})
+
 
 class TestAGoTSettings:
     """Test AGoTSettings Pydantic settings class."""
-    
+
     def test_agot_settings_defaults(self):
         """Test AGoTSettings default values."""
         settings = AGoTSettings()
         assert settings.llm_provider == "openai"
         assert settings.openai_api_key is None
         assert settings.anthropic_api_key is None
-    
+
     @patch.dict(os.environ, {"LLM_PROVIDER": "claude"})
     def test_agot_settings_from_env(self):
         """Test AGoTSettings loading from environment variables."""
         settings = AGoTSettings()
         assert settings.llm_provider == "claude"
-    
-    @patch.dict(os.environ, {
-        "LLM_PROVIDER": "openai",
-        "OPENAI_API_KEY": "test-openai-key",
-        "ANTHROPIC_API_KEY": "test-anthropic-key"
-    })
+
+    @patch.dict(
+        os.environ,
+        {
+            "LLM_PROVIDER": "openai",
+            "OPENAI_API_KEY": "test-openai-key",
+            "ANTHROPIC_API_KEY": "test-anthropic-key",
+        },
+    )
     def test_agot_settings_all_env_vars(self):
         """Test AGoTSettings with all environment variables set."""
         settings = AGoTSettings()
         assert settings.llm_provider == "openai"
         assert settings.openai_api_key == "test-openai-key"
         assert settings.anthropic_api_key == "test-anthropic-key"
-    
+
     def test_agot_settings_validation(self):
         """Test AGoTSettings field validation."""
         settings = AGoTSettings(llm_provider="custom")
         assert settings.llm_provider == "custom"
 
+
 class TestSimpleConfigClasses:
     """Test simple configuration classes."""
-    
+
     def test_app_config_defaults(self):
         """Test AppConfig default values."""
         config = AppConfig()
@@ -204,7 +210,7 @@ class TestSimpleConfigClasses:
         assert config.log_level == "INFO"
         assert config.cors_allowed_origins_str == "*"
         assert config.auth_token is None
-    
+
     def test_app_config_custom_values(self):
         """Test AppConfig with custom values."""
         config = AppConfig(
@@ -215,7 +221,7 @@ class TestSimpleConfigClasses:
             reload=False,
             log_level="DEBUG",
             cors_allowed_origins_str="http://localhost:3000",
-            auth_token="secret"
+            auth_token="secret",
         )
         assert config.name == "Custom App"
         assert config.version == "1.0.0"
@@ -225,7 +231,7 @@ class TestSimpleConfigClasses:
         assert config.log_level == "DEBUG"
         assert config.cors_allowed_origins_str == "http://localhost:3000"
         assert config.auth_token == "secret"
-    
+
     def test_asr_got_default_params(self):
         """Test ASRGoTDefaultParams default values."""
         params = ASRGoTDefaultParams()
@@ -233,60 +239,61 @@ class TestSimpleConfigClasses:
         assert params.confidence_threshold == 0.75
         assert params.max_iterations == 10
         assert params.convergence_threshold == 0.05
-    
+
     def test_asr_got_custom_params(self):
         """Test ASRGoTDefaultParams with custom values."""
         params = ASRGoTDefaultParams(
             initial_confidence=0.9,
             confidence_threshold=0.8,
             max_iterations=20,
-            convergence_threshold=0.01
+            convergence_threshold=0.01,
         )
         assert params.initial_confidence == 0.9
         assert params.confidence_threshold == 0.8
         assert params.max_iterations == 20
         assert params.convergence_threshold == 0.01
-    
+
     def test_pubmed_config_defaults(self):
         """Test PubMedConfig default values."""
         config = PubMedConfig()
         assert config.api_key is None
         assert config.max_results == 20
         assert config.rate_limit_delay == 0.5
-    
+
     def test_google_scholar_config_defaults(self):
         """Test GoogleScholarConfig default values."""
         config = GoogleScholarConfig()
         assert config.max_results == 10
         assert config.rate_limit_delay == 1.0
-    
+
     def test_exa_search_config_defaults(self):
         """Test ExaSearchConfig default values."""
         config = ExaSearchConfig()
         assert config.api_key is None
         assert config.max_results == 10
-    
+
     def test_knowledge_domain_defaults(self):
         """Test KnowledgeDomain default values."""
         domain = KnowledgeDomain("test_domain")
         assert domain.name == "test_domain"
         assert domain.description == ""
         assert domain.keywords == []
-    
+
     def test_knowledge_domain_with_values(self):
         """Test KnowledgeDomain with custom values."""
         domain = KnowledgeDomain(
             "AI",
             description="Artificial Intelligence",
-            keywords=["machine learning", "neural networks"]
+            keywords=["machine learning", "neural networks"],
         )
         assert domain.name == "AI"
         assert domain.description == "Artificial Intelligence"
         assert domain.keywords == ["machine learning", "neural networks"]
 
+
 class TestLegacyConfig:
     """Test LegacyConfig class functionality."""
-    
+
     def test_legacy_config_defaults(self):
         """Test LegacyConfig default initialization."""
         config = LegacyConfig()
@@ -296,14 +303,14 @@ class TestLegacyConfig:
         assert config._frozen is False
         assert isinstance(config.app, AppConfig)
         assert isinstance(config.asr_got, ASRGoTDefaultParams)
-    
+
     def test_legacy_config_custom_values(self, sample_config_data):
         """Test LegacyConfig with custom values."""
         config = LegacyConfig(**sample_config_data)
         assert config.learning_rate == sample_config_data["learning_rate"]
         assert config.batch_size == sample_config_data["batch_size"]
         assert config.max_steps == sample_config_data["max_steps"]
-    
+
     def test_legacy_config_validation_on_init(self):
         """Test LegacyConfig validates parameters on initialization."""
         with pytest.raises(ValueError):
@@ -312,13 +319,13 @@ class TestLegacyConfig:
             LegacyConfig(batch_size=0)
         with pytest.raises(ValueError):
             LegacyConfig(max_steps=-1)
-    
+
     def test_legacy_config_frozen(self):
         """Test LegacyConfig frozen functionality."""
         config = LegacyConfig(frozen=True)
         with pytest.raises(AttributeError, match="Cannot modify frozen config"):
             config.learning_rate = 0.02
-    
+
     def test_legacy_config_equality(self):
         """Test LegacyConfig equality comparison."""
         config1 = LegacyConfig(learning_rate=0.01, batch_size=32, max_steps=1000)
@@ -327,24 +334,20 @@ class TestLegacyConfig:
         assert config1 == config2
         assert config1 != config3
         assert config1 != "not a config"
-    
+
     def test_legacy_config_repr(self):
         """Test LegacyConfig string representation."""
         config = LegacyConfig(learning_rate=0.01, batch_size=32, max_steps=1000)
         expected = "Config(learning_rate=0.01, batch_size=32, max_steps=1000)"
         assert repr(config) == expected
-    
+
     def test_legacy_config_model_dump(self):
         """Test LegacyConfig model_dump method."""
         config = LegacyConfig(learning_rate=0.01, batch_size=32, max_steps=1000)
         dump = config.model_dump()
-        expected = {
-            "learning_rate": 0.01,
-            "batch_size": 32,
-            "max_steps": 1000
-        }
+        expected = {"learning_rate": 0.01, "batch_size": 32, "max_steps": 1000}
         assert dump == expected
-    
+
     def test_legacy_config_copy(self):
         """Test LegacyConfig copy method."""
         original = LegacyConfig(learning_rate=0.01, batch_size=32, max_steps=1000)
@@ -352,20 +355,16 @@ class TestLegacyConfig:
         assert copy == original
         assert copy is not original
         assert copy._frozen is False
-    
+
     def test_legacy_config_update(self):
         """Test LegacyConfig update method."""
         config = LegacyConfig()
-        updates = {
-            "learning_rate": 0.02,
-            "batch_size": 64,
-            "max_steps": 2000
-        }
+        updates = {"learning_rate": 0.02, "batch_size": 64, "max_steps": 2000}
         config.update(updates)
         assert config.learning_rate == 0.02
         assert config.batch_size == 64
         assert config.max_steps == 2000
-    
+
     def test_legacy_config_update_validation(self):
         """Test LegacyConfig update validates values."""
         config = LegacyConfig()
@@ -375,7 +374,7 @@ class TestLegacyConfig:
             config.update({"batch_size": 0})
         with pytest.raises(ValueError):
             config.update({"max_steps": -1})
-    
+
     def test_legacy_config_merge(self):
         """Test LegacyConfig merge method."""
         config1 = LegacyConfig(learning_rate=0.01, batch_size=32, max_steps=1000)
@@ -385,31 +384,32 @@ class TestLegacyConfig:
         assert merged.batch_size == 64
         assert merged.max_steps == 1000  # From config1
 
+
 class TestLegacyConfigFileOperations:
     """Test LegacyConfig file loading and saving operations."""
-    
+
     def test_load_yaml_file(self, temp_config_file):
         """Test loading YAML configuration file."""
         config = LegacyConfig.load(temp_config_file)
         assert config.learning_rate == 0.01
         assert config.batch_size == 32
         assert config.max_steps == 1000
-    
+
     def test_load_json_file(self, temp_json_file):
         """Test loading JSON configuration file."""
         config = LegacyConfig.load(temp_json_file)
         assert config.learning_rate == 0.01
         assert config.batch_size == 32
         assert config.max_steps == 1000
-    
+
     def test_load_nonexistent_file(self):
         """Test loading nonexistent file raises FileNotFoundError."""
         with pytest.raises(FileNotFoundError, match="Config file not found"):
             LegacyConfig.load("/nonexistent/file.yaml")
-    
+
     def test_load_empty_file(self):
         """Test loading empty file raises ValueError."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             f.write("")
             temp_path = f.name
         try:
@@ -417,10 +417,10 @@ class TestLegacyConfigFileOperations:
                 LegacyConfig.load(temp_path)
         finally:
             os.unlink(temp_path)
-    
+
     def test_load_invalid_yaml(self):
         """Test loading invalid YAML raises YAMLError."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             f.write("invalid: yaml: content:")
             temp_path = f.name
         try:
@@ -428,10 +428,10 @@ class TestLegacyConfigFileOperations:
                 LegacyConfig.load(temp_path)
         finally:
             os.unlink(temp_path)
-    
+
     def test_load_invalid_json(self):
         """Test loading invalid JSON raises JSONDecodeError."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             f.write('{"invalid": json}')
             temp_path = f.name
         try:
@@ -439,10 +439,10 @@ class TestLegacyConfigFileOperations:
                 LegacyConfig.load(temp_path)
         finally:
             os.unlink(temp_path)
-    
+
     def test_load_unsupported_format(self):
         """Test loading unsupported file format raises ValueError."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
             f.write("some content")
             temp_path = f.name
         try:
@@ -450,10 +450,10 @@ class TestLegacyConfigFileOperations:
                 LegacyConfig.load(temp_path)
         finally:
             os.unlink(temp_path)
-    
+
     def test_load_missing_required_keys(self):
         """Test loading config with missing required keys raises ValueError."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             yaml.dump({"max_steps": 1000}, f)  # Missing learning_rate and batch_size
             temp_path = f.name
         try:
@@ -461,26 +461,25 @@ class TestLegacyConfigFileOperations:
                 LegacyConfig.load(temp_path)
         finally:
             os.unlink(temp_path)
-    
+
     def test_load_invalid_data_types(self):
         """Test loading config with invalid data types raises ValueError."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
-            yaml.dump({
-                "learning_rate": "not_a_number",
-                "batch_size": 32,
-                "max_steps": 1000
-            }, f)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(
+                {"learning_rate": "not_a_number", "batch_size": 32, "max_steps": 1000},
+                f,
+            )
             temp_path = f.name
         try:
             with pytest.raises(ValueError, match="learning_rate must be a number"):
                 LegacyConfig.load(temp_path)
         finally:
             os.unlink(temp_path)
-    
+
     def test_save_yaml_file(self):
         """Test saving configuration to YAML file."""
         config = LegacyConfig(learning_rate=0.01, batch_size=32, max_steps=1000)
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             temp_path = f.name
         try:
             config.save(temp_path)
@@ -490,11 +489,11 @@ class TestLegacyConfigFileOperations:
         finally:
             if os.path.exists(temp_path):
                 os.unlink(temp_path)
-    
+
     def test_save_json_file(self):
         """Test saving configuration to JSON file."""
         config = LegacyConfig(learning_rate=0.01, batch_size=32, max_steps=1000)
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             temp_path = f.name
         try:
             config.save(temp_path)
@@ -503,13 +502,13 @@ class TestLegacyConfigFileOperations:
         finally:
             if os.path.exists(temp_path):
                 os.unlink(temp_path)
-    
+
     def test_save_unsupported_format(self):
         """Test saving to unsupported format raises ValueError."""
         config = LegacyConfig()
         with pytest.raises(ValueError, match="Unsupported file format"):
             config.save("config.txt")
-    
+
     @patch("builtins.open", side_effect=PermissionError("Permission denied"))
     def test_save_permission_error(self, mock_open):
         """Test saving with permission error raises PermissionError."""
@@ -517,21 +516,20 @@ class TestLegacyConfigFileOperations:
         with pytest.raises(PermissionError, match="Permission denied writing to"):
             config.save("readonly.yaml")
 
+
 class TestLegacyConfigEnvironment:
     """Test LegacyConfig environment variable loading."""
-    
-    @patch.dict(os.environ, {
-        "LEARNING_RATE": "0.02",
-        "BATCH_SIZE": "64",
-        "MAX_STEPS": "2000"
-    })
+
+    @patch.dict(
+        os.environ, {"LEARNING_RATE": "0.02", "BATCH_SIZE": "64", "MAX_STEPS": "2000"}
+    )
     def test_from_env_all_vars(self):
         """Test loading all environment variables."""
         config = LegacyConfig.from_env()
         assert config.learning_rate == 0.02
         assert config.batch_size == 64
         assert config.max_steps == 2000
-    
+
     @patch.dict(os.environ, {"LEARNING_RATE": "0.02"})
     def test_from_env_partial_vars(self):
         """Test loading with partial environment variables."""
@@ -539,7 +537,7 @@ class TestLegacyConfigEnvironment:
         assert config.learning_rate == 0.02
         assert config.batch_size == 32  # Default
         assert config.max_steps == 1000  # Default
-    
+
     @patch.dict(os.environ, {}, clear=True)
     def test_from_env_no_vars(self):
         """Test loading with no environment variables uses defaults."""
@@ -547,15 +545,12 @@ class TestLegacyConfigEnvironment:
         assert config.learning_rate == 0.01
         assert config.batch_size == 32
         assert config.max_steps == 1000
-    
+
     def test_load_with_overrides(self, temp_config_file):
         """Test loading config with hierarchical overrides."""
         # Create override file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
-            yaml.dump({
-                "learning_rate": 0.05,
-                "batch_size": 128
-            }, f)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump({"learning_rate": 0.05, "batch_size": 128}, f)
             override_path = f.name
         try:
             config = LegacyConfig.load_with_overrides(temp_config_file, override_path)
@@ -565,15 +560,15 @@ class TestLegacyConfigEnvironment:
         finally:
             if os.path.exists(override_path):
                 os.unlink(override_path)
-    
+
     def test_load_with_overrides_nonexistent_override(self, temp_config_file):
         """Test loading with nonexistent override file raises error."""
         with pytest.raises(FileNotFoundError, match="Override file not found"):
             LegacyConfig.load_with_overrides(temp_config_file, "/nonexistent.yaml")
-    
+
     def test_load_with_overrides_empty_override(self, temp_config_file):
         """Test loading with empty override file returns base config."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             f.write("")
             override_path = f.name
         try:
@@ -585,9 +580,10 @@ class TestLegacyConfigEnvironment:
             if os.path.exists(override_path):
                 os.unlink(override_path)
 
+
 class TestDataclassConfigurations:
     """Test dataclass-based configuration classes."""
-    
+
     def test_model_config_defaults(self):
         """Test ModelConfig default values."""
         config = ModelConfig()
@@ -597,7 +593,7 @@ class TestDataclassConfigurations:
         assert config.timeout == 30
         assert config.api_key is None
         assert config.base_url is None
-    
+
     def test_model_config_custom_values(self):
         """Test ModelConfig with custom values."""
         config = ModelConfig(
@@ -606,7 +602,7 @@ class TestDataclassConfigurations:
             max_tokens=1024,
             timeout=60,
             api_key="test-key",
-            base_url="https://api.example.com"
+            base_url="https://api.example.com",
         )
         assert config.name == "gpt-3.5-turbo"
         assert config.temperature == 0.5
@@ -614,7 +610,7 @@ class TestDataclassConfigurations:
         assert config.timeout == 60
         assert config.api_key == "test-key"
         assert config.base_url == "https://api.example.com"
-    
+
     def test_graph_config_defaults(self):
         """Test GraphConfig default values."""
         config = GraphConfig()
@@ -623,7 +619,7 @@ class TestDataclassConfigurations:
         assert config.pruning_threshold == 0.1
         assert config.enable_caching is True
         assert config.cache_size == 1000
-    
+
     def test_logging_config_defaults(self):
         """Test LoggingConfig default values."""
         config = LoggingConfig()
@@ -631,27 +627,20 @@ class TestDataclassConfigurations:
         assert config.format == "{time:YYYY-MM-DD HH:mm:ss} | {level} | {message}"
         assert config.file_path is None
         assert config.enable_console is True
-    
+
     def test_config_defaults(self):
         """Test main Config class default values."""
         config = Config()
         assert isinstance(config.model, ModelConfig)
         assert isinstance(config.graph, GraphConfig)
         assert isinstance(config.logging, LoggingConfig)
-    
+
     def test_config_from_dict(self):
         """Test Config.from_dict class method."""
         data = {
-            "model": {
-                "name": "custom-model",
-                "temperature": 0.8
-            },
-            "graph": {
-                "max_depth": 10
-            },
-            "logging": {
-                "level": "DEBUG"
-            }
+            "model": {"name": "custom-model", "temperature": 0.8},
+            "graph": {"max_depth": 10},
+            "logging": {"level": "DEBUG"},
         }
         config = Config.from_dict(data)
         assert config.model.name == "custom-model"
@@ -661,7 +650,7 @@ class TestDataclassConfigurations:
         # Test defaults for unspecified values
         assert config.model.max_tokens == 2048  # Default
         assert config.graph.max_breadth == 3  # Default
-    
+
     def test_config_to_dict(self):
         """Test Config.to_dict method."""
         config = Config()
@@ -671,7 +660,7 @@ class TestDataclassConfigurations:
         assert "logging" in data
         assert data["model"]["name"] == "gpt-4"
         assert data["graph"]["max_depth"] == 5
-    
+
     def test_config_to_json(self):
         """Test Config.to_json method."""
         config = Config()
@@ -679,7 +668,7 @@ class TestDataclassConfigurations:
         data = json.loads(json_str)
         assert data["model"]["name"] == "gpt-4"
         assert data["graph"]["max_depth"] == 5
-    
+
     def test_config_to_yaml(self):
         """Test Config.to_yaml method."""
         config = Config()
@@ -688,17 +677,18 @@ class TestDataclassConfigurations:
         assert data["model"]["name"] == "gpt-4"
         assert data["graph"]["max_depth"] == 5
 
+
 class TestConfigFileOperations:
     """Test Config file operations."""
-    
+
     def test_from_file_yaml(self):
         """Test Config.from_file with YAML file."""
         data = {
             "model": {"name": "test-model", "temperature": 0.9},
             "graph": {"max_depth": 7},
-            "logging": {"level": "DEBUG"}
+            "logging": {"level": "DEBUG"},
         }
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             yaml.dump(data, f)
             temp_path = f.name
         try:
@@ -709,15 +699,15 @@ class TestConfigFileOperations:
             assert config.logging.level == "DEBUG"
         finally:
             os.unlink(temp_path)
-    
+
     def test_from_file_json(self):
         """Test Config.from_file with JSON file."""
         data = {
             "model": {"name": "test-model", "temperature": 0.9},
             "graph": {"max_depth": 7},
-            "logging": {"level": "DEBUG"}
+            "logging": {"level": "DEBUG"},
         }
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             json.dump(data, f)
             temp_path = f.name
         try:
@@ -728,15 +718,15 @@ class TestConfigFileOperations:
             assert config.logging.level == "DEBUG"
         finally:
             os.unlink(temp_path)
-    
+
     def test_from_file_nonexistent(self):
         """Test Config.from_file with nonexistent file."""
         with pytest.raises(FileNotFoundError, match="Configuration file not found"):
             Config.from_file("/nonexistent/file.yaml")
-    
+
     def test_from_file_empty(self):
         """Test Config.from_file with empty file."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             f.write("")
             temp_path = f.name
         try:
@@ -744,10 +734,10 @@ class TestConfigFileOperations:
                 Config.from_file(temp_path)
         finally:
             os.unlink(temp_path)
-    
+
     def test_from_file_unsupported_format(self):
         """Test Config.from_file with unsupported format."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
             f.write("some content")
             temp_path = f.name
         try:
@@ -755,13 +745,13 @@ class TestConfigFileOperations:
                 Config.from_file(temp_path)
         finally:
             os.unlink(temp_path)
-    
+
     def test_save_to_file_yaml(self):
         """Test Config.save_to_file with YAML format."""
         config = Config()
         config.model.name = "saved-model"
         config.graph.max_depth = 8
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             temp_path = f.name
         try:
             config.save_to_file(temp_path)
@@ -771,13 +761,13 @@ class TestConfigFileOperations:
         finally:
             if os.path.exists(temp_path):
                 os.unlink(temp_path)
-    
+
     def test_save_to_file_json(self):
         """Test Config.save_to_file with JSON format."""
         config = Config()
         config.model.name = "saved-model"
         config.graph.max_depth = 8
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             temp_path = f.name
         try:
             config.save_to_file(temp_path)
@@ -787,26 +777,29 @@ class TestConfigFileOperations:
         finally:
             if os.path.exists(temp_path):
                 os.unlink(temp_path)
-    
+
     def test_save_to_file_unsupported_format(self):
         """Test Config.save_to_file with unsupported format."""
         config = Config()
         with pytest.raises(ValueError, match="Unsupported file format"):
             config.save_to_file("config.txt")
-    
+
     @patch("builtins.open", side_effect=PermissionError("Permission denied"))
     def test_save_to_file_permission_error(self, mock_open):
         """Test Config.save_to_file with permission error."""
         config = Config()
         with pytest.raises(RuntimeError, match="Failed to save configuration"):
             config.save_to_file("readonly.yaml")
-    
-    @patch.dict(os.environ, {
-        "AGOT_MODEL_NAME": "env-model",
-        "AGOT_MODEL_TEMPERATURE": "0.8",
-        "AGOT_GRAPH_MAX_DEPTH": "6",
-        "AGOT_LOGGING_LEVEL": "DEBUG"
-    })
+
+    @patch.dict(
+        os.environ,
+        {
+            "AGOT_MODEL_NAME": "env-model",
+            "AGOT_MODEL_TEMPERATURE": "0.8",
+            "AGOT_GRAPH_MAX_DEPTH": "6",
+            "AGOT_LOGGING_LEVEL": "DEBUG",
+        },
+    )
     def test_from_env_with_defaults(self):
         """Test Config.from_env with default prefix."""
         config = Config.from_env()
@@ -814,24 +807,24 @@ class TestConfigFileOperations:
         assert config.model.temperature == 0.8
         assert config.graph.max_depth == 6
         assert config.logging.level == "DEBUG"
-    
-    @patch.dict(os.environ, {
-        "CUSTOM_MODEL_NAME": "custom-model",
-        "CUSTOM_MODEL_TEMPERATURE": "0.9"
-    })
+
+    @patch.dict(
+        os.environ,
+        {"CUSTOM_MODEL_NAME": "custom-model", "CUSTOM_MODEL_TEMPERATURE": "0.9"},
+    )
     def test_from_env_custom_prefix(self):
         """Test Config.from_env with custom prefix."""
         config = Config.from_env(prefix="CUSTOM_")
         assert config.model.name == "custom-model"
         assert config.model.temperature == 0.9
         assert config.graph.max_depth == 5  # Default
-    
+
     @patch.dict(os.environ, {"AGOT_MODEL_TEMPERATURE": "invalid"})
     def test_from_env_invalid_value(self):
         """Test Config.from_env with invalid environment value."""
         with pytest.raises(ValueError, match="Invalid value for"):
             Config.from_env()
-    
+
     @patch.dict(os.environ, {"AGOT_GRAPH_ENABLE_CACHING": "true"})
     def test_from_env_boolean_values(self):
         """Test Config.from_env with boolean environment values."""
@@ -844,24 +837,29 @@ class TestConfigFileOperations:
             config = Config.from_env()
             assert config.graph.enable_caching is False
 
+
 class TestConfigValidationAndUpdates:
     """Test Config validation and update functionality."""
-    
+
     def test_validate_valid_config(self):
         """Test validation passes for valid configuration."""
         config = Config()
         config.validate()  # Should not raise
-    
+
     def test_validate_invalid_temperature(self):
         """Test validation fails for invalid temperature."""
         config = Config()
         config.model.temperature = -0.1
-        with pytest.raises(ValueError, match="Model temperature must be between 0.0 and 2.0"):
+        with pytest.raises(
+            ValueError, match="Model temperature must be between 0.0 and 2.0"
+        ):
             config.validate()
         config.model.temperature = 2.1
-        with pytest.raises(ValueError, match="Model temperature must be between 0.0 and 2.0"):
+        with pytest.raises(
+            ValueError, match="Model temperature must be between 0.0 and 2.0"
+        ):
             config.validate()
-    
+
     def test_validate_invalid_max_tokens(self):
         """Test validation fails for invalid max_tokens."""
         config = Config()
@@ -871,14 +869,14 @@ class TestConfigValidationAndUpdates:
         config.model.max_tokens = -100
         with pytest.raises(ValueError, match="Model max_tokens must be positive"):
             config.validate()
-    
+
     def test_validate_invalid_timeout(self):
         """Test validation fails for invalid timeout."""
         config = Config()
         config.model.timeout = 0
         with pytest.raises(ValueError, match="Model timeout must be positive"):
             config.validate()
-    
+
     def test_validate_invalid_graph_params(self):
         """Test validation fails for invalid graph parameters."""
         config = Config()
@@ -891,20 +889,22 @@ class TestConfigValidationAndUpdates:
             config.validate()
         config.graph.max_breadth = 3
         config.graph.pruning_threshold = 1.5
-        with pytest.raises(ValueError, match="Graph pruning_threshold must be between 0.0 and 1.0"):
+        with pytest.raises(
+            ValueError, match="Graph pruning_threshold must be between 0.0 and 1.0"
+        ):
             config.validate()
         config.graph.pruning_threshold = 0.1
         config.graph.cache_size = 0
         with pytest.raises(ValueError, match="Graph cache_size must be positive"):
             config.validate()
-    
+
     def test_validate_invalid_logging_level(self):
         """Test validation fails for invalid logging level."""
         config = Config()
         config.logging.level = "INVALID"
         with pytest.raises(ValueError, match="Logging level must be one of"):
             config.validate()
-    
+
     def test_update_model_section(self):
         """Test updating model section."""
         config = Config()
@@ -912,50 +912,53 @@ class TestConfigValidationAndUpdates:
         assert config.model.name == "updated-model"
         assert config.model.temperature == 0.8
         assert config.model.max_tokens == 2048  # Unchanged
-    
+
     def test_update_multiple_sections(self):
         """Test updating multiple sections."""
         config = Config()
         config.update(
             model={"name": "updated-model"},
             graph={"max_depth": 8},
-            logging={"level": "DEBUG"}
+            logging={"level": "DEBUG"},
         )
         assert config.model.name == "updated-model"
         assert config.graph.max_depth == 8
         assert config.logging.level == "DEBUG"
-    
+
     def test_update_unknown_section(self):
         """Test updating unknown section logs warning."""
         config = Config()
-        with patch('logging.warning') as mock_warning:
+        with patch("logging.warning") as mock_warning:
             config.update(unknown_section={"key": "value"})
             mock_warning.assert_called_with("Unknown config key: %s", "unknown_section")
-    
+
     def test_update_unknown_nested_key(self):
         """Test updating unknown nested key logs warning."""
         config = Config()
-        with patch('logging.warning') as mock_warning:
+        with patch("logging.warning") as mock_warning:
             config.update(model={"unknown_key": "value"})
-            mock_warning.assert_called_with("Unknown nested config key: %s.%s", "model", "unknown_key")
+            mock_warning.assert_called_with(
+                "Unknown nested config key: %s.%s", "model", "unknown_key"
+            )
+
 
 class TestGlobalConfigFunctions:
     """Test global configuration functions."""
-    
+
     def test_get_config_singleton(self):
         """Test get_config returns singleton instance."""
         config1 = get_config()
         config2 = get_config()
         assert config1 is config2
         assert isinstance(config1, Config)
-    
+
     def test_set_config_validation(self):
         """Test set_config validates configuration."""
         invalid_config = Config()
         invalid_config.model.temperature = -1.0
         with pytest.raises(ValueError):
             set_config(invalid_config)
-    
+
     def test_set_config_valid(self):
         """Test set_config with valid configuration."""
         new_config = Config()
@@ -963,11 +966,11 @@ class TestGlobalConfigFunctions:
         set_config(new_config)
         retrieved_config = get_config()
         assert retrieved_config.model.name == "test-model"
-    
+
     def test_load_config_file_only(self):
         """Test load_config with file only."""
         data = {"model": {"name": "file-model"}}
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             yaml.dump(data, f)
             temp_path = f.name
         try:
@@ -975,18 +978,18 @@ class TestGlobalConfigFunctions:
             assert config.model.name == "file-model"
         finally:
             os.unlink(temp_path)
-    
+
     @patch.dict(os.environ, {"TEST_MODEL_NAME": "env-model"})
     def test_load_config_env_only(self):
         """Test load_config with environment variables only."""
         config = load_config(env_prefix="TEST_")
         assert config.model.name == "env-model"
-    
+
     @patch.dict(os.environ, {"TEST_MODEL_NAME": "env-model"})
     def test_load_config_file_and_env(self):
         """Test load_config with both file and environment variables."""
         data = {"model": {"temperature": 0.9}}
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             yaml.dump(data, f)
             temp_path = f.name
         try:
@@ -995,35 +998,38 @@ class TestGlobalConfigFunctions:
             assert config.model.temperature == 0.9  # From file
         finally:
             os.unlink(temp_path)
-    
+
     def test_load_config_invalid_file_continues(self):
         """Test load_config continues with invalid file."""
-        with patch('logging.warning') as mock_warning:
+        with patch("logging.warning") as mock_warning:
             config = load_config(file_path="/nonexistent/file.yaml")
             assert isinstance(config, Config)
             mock_warning.assert_called()
-    
+
     @patch.dict(os.environ, {"TEST_MODEL_TEMPERATURE": "invalid"})
     def test_load_config_invalid_env_continues(self):
         """Test load_config continues with invalid environment variables."""
-        with patch('logging.warning') as mock_warning:
+        with patch("logging.warning") as mock_warning:
             config = load_config(env_prefix="TEST_")
             assert isinstance(config, Config)
             mock_warning.assert_called()
 
+
 class TestThreadSafety:
     """Test thread safety of configuration operations."""
-    
+
     def test_legacy_config_thread_safety(self):
         """Test LegacyConfig thread safety with config lock."""
         results = []
         errors = []
+
         def create_config():
             try:
                 config = LegacyConfig(learning_rate=0.01, batch_size=32, max_steps=1000)
                 results.append(config)
             except Exception as e:
                 errors.append(e)
+
         threads = [threading.Thread(target=create_config) for _ in range(10)]
         for thread in threads:
             thread.start()
@@ -1032,11 +1038,12 @@ class TestThreadSafety:
         assert len(errors) == 0
         assert len(results) == 10
         assert all(isinstance(c, LegacyConfig) for c in results)
-    
+
     def test_concurrent_config_access(self):
         """Test concurrent access to global configuration."""
         results = []
         errors = []
+
         def access_config():
             try:
                 cfg = get_config()
@@ -1044,6 +1051,7 @@ class TestThreadSafety:
                 time.sleep(0.001)
             except Exception as e:
                 errors.append(e)
+
         threads = [threading.Thread(target=access_config) for _ in range(20)]
         for thread in threads:
             thread.start()
@@ -1052,9 +1060,10 @@ class TestThreadSafety:
         assert len(errors) == 0
         assert len(results) == 20
 
+
 class TestEdgeCases:
     """Test edge cases and error conditions."""
-    
+
     def test_settings_alias_compatibility(self):
         """Test Settings alias works correctly."""
         settings_config = Settings(learning_rate=0.02, batch_size=64, max_steps=2000)
@@ -1062,7 +1071,7 @@ class TestEdgeCases:
         assert settings_config.learning_rate == 0.02
         assert settings_config.batch_size == 64
         assert settings_config.max_steps == 2000
-    
+
     def test_global_config_instances(self):
         """Test global configuration instances are accessible."""
         assert isinstance(config, LegacyConfig)
@@ -1070,21 +1079,24 @@ class TestEdgeCases:
         assert isinstance(env_settings, AGoTSettings)
         assert isinstance(runtime_settings, RuntimeSettings)
         assert settings is runtime_settings
-    
+
     def test_runtime_settings_loading(self):
         """Test runtime settings loading function."""
         loaded_settings = load_runtime_settings()
         assert isinstance(loaded_settings, RuntimeSettings)
         assert isinstance(loaded_settings.app, AppSettingsModel)
         assert isinstance(loaded_settings.neo4j, Neo4jSettingsModel)
-    
+
     def test_large_config_handling(self):
         """Test handling of large configuration structures."""
         large_kwargs = {f"param_{i}": f"value_{i}" for i in range(1000)}
-        cfg = LegacyConfig(learning_rate=0.01, batch_size=32, max_steps=1000, **large_kwargs)
+        cfg = LegacyConfig(
+            learning_rate=0.01, batch_size=32, max_steps=1000, **large_kwargs
+        )
         assert cfg.learning_rate == 0.01
         assert cfg.batch_size == 32
         assert cfg.max_steps == 1000
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- define SettingsFileModel and related Pydantic models for schema
- validate settings.yaml when loading runtime settings
- fix malformed server_name entry in settings.yaml
- update tests to cover new validation logic

## Testing
- `ruff format src/adaptive_graph_of_thoughts/config.py tests/unit/config/test_config_validation.py tests/unit/test_config.py`
- `ruff check src/adaptive_graph_of_thoughts/config.py tests/unit/config/test_config_validation.py tests/unit/test_config.py` *(fails: unused imports in unchanged tests)*
- `pytest -q` *(fails: missing dependencies)*
- `mypy src` *(fails: syntax error in unrelated file)*
- `pyright src` *(fails: type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68557cbdc890832ab11b1a53647326f0