### PR TITLE
Fix MCP inspector executor

### DIFF
--- a/scripts/mcp_inspector_executor.py
+++ b/scripts/mcp_inspector_executor.py
@@ -17,7 +17,23 @@ if __name__ == "__main__":
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )
-        time.sleep(2)
+        
+        # Wait for server to be ready with retries
+        import requests
+        max_retries = 10
+        for i in range(max_retries):
+            time.sleep(0.5)
+            try:
+                response = requests.get("http://localhost:8000/health", timeout=1)
+                if response.status_code == 200:
+                    break
+            except (requests.RequestException, requests.ConnectionError):
+                if i == max_retries - 1:
+                    server_proc.terminate()
+                    server_proc.wait()
+                    raise RuntimeError("HTTP server failed to start within timeout")
+                continue
+
         command = [
             "mcp-inspector",
             "--cli",

--- a/scripts/mcp_inspector_executor.py
+++ b/scripts/mcp_inspector_executor.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+import time
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
@@ -7,20 +8,33 @@ if __name__ == "__main__":
         sys.exit(1)
 
     mode = sys.argv[1]
-    command = []
+    command: list[str]
 
     if mode == "http":
-        command = ["mcp-inspector", "-v", "validate", "http://localhost:8000/mcp"]
+        # Start the HTTP server first
+        server_proc = subprocess.Popen(
+            ["python3", "src/adaptive_graph_of_thoughts/main.py"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        time.sleep(2)
+        command = [
+            "mcp-inspector",
+            "--cli",
+            "http://localhost:8000/mcp",
+            "--method",
+            "tools/list",
+        ]
     elif mode == "stdio":
         command = [
             "mcp-inspector",
-            "-v",
-            "validate",
-            "stdio",
-            "--program",
+            "--cli",
             "python3",
             "src/adaptive_graph_of_thoughts/main_stdio.py",
+            "--method",
+            "tools/list",
         ]
+        server_proc = None
     else:
         print(f"Unknown mode: {mode}. Supported modes are http, stdio.")
         sys.exit(1)
@@ -28,8 +42,8 @@ if __name__ == "__main__":
     try:
         print(f"Running command: {' '.join(command)}")
         result = subprocess.run(
-            command, capture_output=True, text=True, check=True, timeout=480
-        )  # e.g., 480 seconds, or make configurable
+            command, capture_output=True, text=True, check=True, timeout=120
+        )
         print("MCP Inspector output:")
         print(result.stdout)
         if result.stderr:
@@ -53,3 +67,7 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"An unexpected error occurred: {e}")
         sys.exit(1)
+    finally:
+        if server_proc is not None:
+            server_proc.terminate()
+            server_proc.wait()


### PR DESCRIPTION
## Summary
- update `mcp_inspector_executor.py` to use the CLI mode
- start HTTP server when invoking inspector in HTTP mode
- drop the verbose flag
- add cleanup of spawned server processes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685766da5434832a8c2819be828f609b