### PR TITLE
Fix authentication bypass in verify_token

### DIFF
--- a/src/adaptive_graph_of_thoughts/api/routes/mcp.py
+++ b/src/adaptive_graph_of_thoughts/api/routes/mcp.py
@@ -1,4 +1,5 @@
-import secrets
+import hashlib
+import hmac
 import time
 from typing import Any, Optional, Union
 
@@ -40,34 +41,23 @@ def _parse_dot_notation(params: dict[str, str]) -> dict[str, Any]:
 
 # Dependency for authentication
 async def verify_token(http_request: Request):
-    if os.getenv("SMITHERY_MODE", "false").lower() == "true":
-        logger.debug("Smithery mode: skipping token verification")
-        return True
-    
-    if settings.app.auth_token:
-        auth_header = http_request.headers.get("Authorization")
-        if not auth_header:
-            logger.warning(
-                "MCP request missing Authorization header when auth_token is configured."
-            )
-            raise HTTPException(status_code=401, detail="Not authenticated")
+    """Verify Bearer token from the Authorization header."""
 
-        parts = auth_header.split()
-        if len(parts) != 2 or parts[0].lower() != "bearer":
-            logger.warning(
-                f"MCP request with malformed Authorization header: {auth_header}"
-            )
-            raise HTTPException(
-                status_code=401, detail="Invalid authentication credentials"
-            )
+    if not settings.app.auth_token:
+        raise HTTPException(status_code=401, detail="Authentication required")
 
-        token = parts[1]
-        if not secrets.compare_digest(token, settings.app.auth_token):
-            logger.warning("MCP request with invalid token.")
-            raise HTTPException(status_code=403, detail="Invalid token")
-        logger.debug("MCP request authenticated successfully via token.")
-    else:
-        logger.debug("MCP auth_token not configured, skipping authentication.")
+    auth_header = http_request.headers.get("Authorization")
+    if not auth_header or not auth_header.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Invalid authorization header")
+
+    token = auth_header[7:]
+
+    expected_hash = hashlib.sha256(settings.app.auth_token.encode()).hexdigest()
+    provided_hash = hashlib.sha256(token.encode()).hexdigest()
+
+    if not hmac.compare_digest(expected_hash, provided_hash):
+        raise HTTPException(status_code=403, detail="Invalid token")
+
     return True
 
 


### PR DESCRIPTION
## Summary
- secure the API by removing Smithery mode bypass
- use constant-time token comparison with SHA-256
- clean up imports

## Testing
- `poetry run pytest`
- `poetry run ruff check src/adaptive_graph_of_thoughts/api/routes/mcp.py`

------
https://chatgpt.com/codex/tasks/task_e_68579b51cdc4832a994d637342c3e352