### PR TITLE
Add prompt validation for LLM requests

### DIFF
--- a/src/adaptive_graph_of_thoughts/config.py
+++ b/src/adaptive_graph_of_thoughts/config.py
@@ -317,12 +317,8 @@ class LegacyConfig:
         cls,
         base_file: str,
         override_file: str,
-    def load_with_overrides(
-        base_path: Path,
-        override_path: Path,
         *,
         _loading_stack: Optional[set[Path]] = None,
-    ) -> Config:
     ) -> "LegacyConfig":
         """Load config with hierarchical overrides.
 
@@ -345,7 +341,9 @@ class LegacyConfig:
         override_path = Path(override_file).resolve()
 
         if base_path == override_path:
-            raise ValueError(f"Circular dependency detected: config file '{base_path}' cannot override itself.")
+            raise ValueError(
+                f"Circular dependency detected: config file '{base_path}' cannot override itself."
+            )
 
         if base_path in _loading_stack or override_path in _loading_stack:
             # Add current base_path to the stack for a more informative error message

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch, MagicMock
 import os
 from adaptive_graph_of_thoughts.services.llm import ask_llm, LLM_QUERY_LOGS
 
+
 @pytest.fixture
 def mock_env_settings_claude():
     """Mock environment settings for Claude provider"""
@@ -10,6 +11,7 @@ def mock_env_settings_claude():
     mock_settings.llm_provider = "claude"
     mock_settings.anthropic_api_key = "test_claude_key"
     return mock_settings
+
 
 @pytest.fixture
 def mock_env_settings_openai():
@@ -19,12 +21,14 @@ def mock_env_settings_openai():
     mock_settings.openai_api_key = "test_openai_key"
     return mock_settings
 
+
 @pytest.fixture
 def mock_claude_response():
     """Mock Claude API response"""
     mock_response = Mock()
     mock_response.content = [Mock(text="Claude response text")]
     return mock_response
+
 
 @pytest.fixture
 def mock_openai_response():
@@ -33,6 +37,7 @@ def mock_openai_response():
     mock_response.choices = [Mock(message=Mock(content="  OpenAI response text  "))]
     return mock_response
 
+
 @pytest.fixture(autouse=True)
 def clear_llm_logs():
     """Clear LLM query logs before each test"""
@@ -40,10 +45,13 @@ def clear_llm_logs():
     yield
     LLM_QUERY_LOGS.clear()
 
+
 class TestLLMClaudeProvider:
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.anthropic')
-    def test_ask_llm_claude_success(self, mock_anthropic, mock_env_settings, mock_claude_response):
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.anthropic")
+    def test_ask_llm_claude_success(
+        self, mock_anthropic, mock_env_settings, mock_claude_response
+    ):
         """Test successful LLM call with Claude provider"""
         mock_env_settings.llm_provider = "claude"
         mock_env_settings.anthropic_api_key = "test_key"
@@ -58,13 +66,15 @@ class TestLLMClaudeProvider:
         mock_anthropic.Anthropic.assert_called_once_with(api_key="test_key")
         mock_client.messages.create.assert_called_once_with(
             model="claude-3-sonnet-20240229",
-            messages=[{"role": "user", "content": "Test prompt"}]
+            messages=[{"role": "user", "content": "Test prompt"}],
         )
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.anthropic')
-    @patch.dict(os.environ, {'CLAUDE_MODEL': 'claude-3-opus-20240229'})
-    def test_ask_llm_claude_custom_model(self, mock_anthropic, mock_env_settings, mock_claude_response):
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.anthropic")
+    @patch.dict(os.environ, {"CLAUDE_MODEL": "claude-3-opus-20240229"})
+    def test_ask_llm_claude_custom_model(
+        self, mock_anthropic, mock_env_settings, mock_claude_response
+    ):
         """Test Claude provider with custom model from environment variable"""
         mock_env_settings.llm_provider = "claude"
         mock_env_settings.anthropic_api_key = "test_key"
@@ -78,11 +88,11 @@ class TestLLMClaudeProvider:
         assert result == "Claude response text"
         mock_client.messages.create.assert_called_once_with(
             model="claude-3-opus-20240229",
-            messages=[{"role": "user", "content": "Test prompt"}]
+            messages=[{"role": "user", "content": "Test prompt"}],
         )
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.anthropic')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.anthropic")
     def test_ask_llm_claude_api_error(self, mock_anthropic, mock_env_settings):
         """Test Claude provider with API error"""
         mock_env_settings.llm_provider = "claude"
@@ -96,9 +106,11 @@ class TestLLMClaudeProvider:
 
         assert result == "LLM error: API Error"
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.anthropic')
-    def test_ask_llm_claude_case_insensitive(self, mock_anthropic, mock_env_settings, mock_claude_response):
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.anthropic")
+    def test_ask_llm_claude_case_insensitive(
+        self, mock_anthropic, mock_env_settings, mock_claude_response
+    ):
         """Test Claude provider with case insensitive provider name"""
         mock_env_settings.llm_provider = "CLAUDE"
         mock_env_settings.anthropic_api_key = "test_key"
@@ -111,10 +123,13 @@ class TestLLMClaudeProvider:
 
         assert result == "Claude response text"
 
+
 class TestLLMOpenAIProvider:
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
-    def test_ask_llm_openai_success(self, mock_openai, mock_env_settings, mock_openai_response):
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
+    def test_ask_llm_openai_success(
+        self, mock_openai, mock_env_settings, mock_openai_response
+    ):
         """Test successful LLM call with OpenAI provider"""
         mock_env_settings.llm_provider = "openai"
         mock_env_settings.openai_api_key = "test_key"
@@ -128,14 +143,15 @@ class TestLLMOpenAIProvider:
         assert result == "OpenAI response text"
         mock_openai.OpenAI.assert_called_once_with(api_key="test_key")
         mock_client.chat.completions.create.assert_called_once_with(
-            model="gpt-3.5-turbo",
-            messages=[{"role": "user", "content": "Test prompt"}]
+            model="gpt-3.5-turbo", messages=[{"role": "user", "content": "Test prompt"}]
         )
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
-    @patch.dict(os.environ, {'OPENAI_MODEL': 'gpt-4'})
-    def test_ask_llm_openai_custom_model(self, mock_openai, mock_env_settings, mock_openai_response):
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
+    @patch.dict(os.environ, {"OPENAI_MODEL": "gpt-4"})
+    def test_ask_llm_openai_custom_model(
+        self, mock_openai, mock_env_settings, mock_openai_response
+    ):
         """Test OpenAI provider with custom model from environment variable"""
         mock_env_settings.llm_provider = "openai"
         mock_env_settings.openai_api_key = "test_key"
@@ -148,12 +164,11 @@ class TestLLMOpenAIProvider:
 
         assert result == "OpenAI response text"
         mock_client.chat.completions.create.assert_called_once_with(
-            model="gpt-4",
-            messages=[{"role": "user", "content": "Test prompt"}]
+            model="gpt-4", messages=[{"role": "user", "content": "Test prompt"}]
         )
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_ask_llm_openai_api_error(self, mock_openai, mock_env_settings):
         """Test OpenAI provider with API error"""
         mock_env_settings.llm_provider = "openai"
@@ -167,9 +182,11 @@ class TestLLMOpenAIProvider:
 
         assert result == "LLM error: API Error"
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
-    def test_ask_llm_openai_default_provider(self, mock_openai, mock_env_settings, mock_openai_response):
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
+    def test_ask_llm_openai_default_provider(
+        self, mock_openai, mock_env_settings, mock_openai_response
+    ):
         """Test that non-Claude provider defaults to OpenAI"""
         mock_env_settings.llm_provider = "unknown_provider"
         mock_env_settings.openai_api_key = "test_key"
@@ -182,15 +199,17 @@ class TestLLMOpenAIProvider:
 
         assert result == "OpenAI response text"
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_ask_llm_openai_response_stripping(self, mock_openai, mock_env_settings):
         """Test that OpenAI response content is properly stripped of whitespace"""
         mock_env_settings.llm_provider = "openai"
         mock_env_settings.openai_api_key = "test_key"
 
         mock_response = Mock()
-        mock_response.choices = [Mock(message=Mock(content="  \n  Response with whitespace  \n  "))]
+        mock_response.choices = [
+            Mock(message=Mock(content="  \n  Response with whitespace  \n  "))
+        ]
 
         mock_client = Mock()
         mock_client.chat.completions.create.return_value = mock_response
@@ -200,10 +219,13 @@ class TestLLMOpenAIProvider:
 
         assert result == "Response with whitespace"
 
+
 class TestLLMQueryLogging:
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
-    def test_llm_query_logging_single_call(self, mock_openai, mock_env_settings, mock_openai_response):
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
+    def test_llm_query_logging_single_call(
+        self, mock_openai, mock_env_settings, mock_openai_response
+    ):
         """Test that LLM queries are logged correctly"""
         mock_env_settings.llm_provider = "openai"
         mock_env_settings.openai_api_key = "test_key"
@@ -218,8 +240,8 @@ class TestLLMQueryLogging:
         assert LLM_QUERY_LOGS[0]["prompt"] == "Test prompt"
         assert LLM_QUERY_LOGS[0]["response"] == "OpenAI response text"
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_llm_query_logging_multiple_calls(self, mock_openai, mock_env_settings):
         """Test multiple LLM query logging"""
         mock_env_settings.llm_provider = "openai"
@@ -241,8 +263,8 @@ class TestLLMQueryLogging:
             assert LLM_QUERY_LOGS[i]["prompt"] == f"Prompt {i}"
             assert LLM_QUERY_LOGS[i]["response"] == f"Response {i}"
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_llm_query_logging_rotation(self, mock_openai, mock_env_settings):
         """Test that LLM query logs are rotated after 5 entries"""
         mock_env_settings.llm_provider = "openai"
@@ -266,8 +288,8 @@ class TestLLMQueryLogging:
             assert LLM_QUERY_LOGS[i]["prompt"] == f"Prompt {expected_index}"
             assert LLM_QUERY_LOGS[i]["response"] == f"Response {expected_index}"
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_llm_query_logging_error_not_logged(self, mock_openai, mock_env_settings):
         """Test that failed LLM queries are not logged"""
         mock_env_settings.llm_provider = "openai"
@@ -283,29 +305,25 @@ class TestLLMQueryLogging:
         assert len(LLM_QUERY_LOGS) == 0
         assert result == "LLM error: API Error"
 
+
 class TestLLMEdgeCases:
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
-    def test_ask_llm_empty_prompt(self, mock_openai, mock_env_settings, mock_openai_response):
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
+    def test_ask_llm_empty_prompt(
+        self, mock_openai, mock_env_settings, mock_openai_response
+    ):
         """Test LLM call with empty prompt"""
         mock_env_settings.llm_provider = "openai"
         mock_env_settings.openai_api_key = "test_key"
 
-        mock_client = Mock()
-        mock_client.chat.completions.create.return_value = mock_openai_response
-        mock_openai.OpenAI.return_value = mock_client
+        with pytest.raises(ValueError, match="Prompt cannot be empty"):
+            ask_llm("")
 
-        result = ask_llm("")
-
-        assert result == "OpenAI response text"
-        mock_client.chat.completions.create.assert_called_once_with(
-            model="gpt-3.5-turbo",
-            messages=[{"role": "user", "content": ""}]
-        )
-
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
-    def test_ask_llm_very_long_prompt(self, mock_openai, mock_env_settings, mock_openai_response):
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
+    def test_ask_llm_very_long_prompt(
+        self, mock_openai, mock_env_settings, mock_openai_response
+    ):
         """Test LLM call with very long prompt"""
         mock_env_settings.llm_provider = "openai"
         mock_env_settings.openai_api_key = "test_key"
@@ -319,13 +337,14 @@ class TestLLMEdgeCases:
 
         assert result == "OpenAI response text"
         mock_client.chat.completions.create.assert_called_once_with(
-            model="gpt-3.5-turbo",
-            messages=[{"role": "user", "content": long_prompt}]
+            model="gpt-3.5-turbo", messages=[{"role": "user", "content": long_prompt}]
         )
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
-    def test_ask_llm_special_characters(self, mock_openai, mock_env_settings, mock_openai_response):
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
+    def test_ask_llm_special_characters(
+        self, mock_openai, mock_env_settings, mock_openai_response
+    ):
         """Test LLM call with special characters in prompt"""
         mock_env_settings.llm_provider = "openai"
         mock_env_settings.openai_api_key = "test_key"
@@ -340,12 +359,14 @@ class TestLLMEdgeCases:
         assert result == "OpenAI response text"
         mock_client.chat.completions.create.assert_called_once_with(
             model="gpt-3.5-turbo",
-            messages=[{"role": "user", "content": special_prompt}]
+            messages=[{"role": "user", "content": special_prompt}],
         )
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
-    def test_ask_llm_unicode_prompt(self, mock_openai, mock_env_settings, mock_openai_response):
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
+    def test_ask_llm_unicode_prompt(
+        self, mock_openai, mock_env_settings, mock_openai_response
+    ):
         """Test LLM call with unicode characters in prompt"""
         mock_env_settings.llm_provider = "openai"
         mock_env_settings.openai_api_key = "test_key"
@@ -360,11 +381,32 @@ class TestLLMEdgeCases:
         assert result == "OpenAI response text"
         mock_client.chat.completions.create.assert_called_once_with(
             model="gpt-3.5-turbo",
-            messages=[{"role": "user", "content": unicode_prompt}]
+            messages=[{"role": "user", "content": unicode_prompt}],
         )
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.anthropic')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
+    def test_prompt_sanitization(
+        self, mock_openai, mock_env_settings, mock_openai_response
+    ):
+        """Ensure potentially harmful content is sanitized before sending"""
+        mock_env_settings.llm_provider = "openai"
+        mock_env_settings.openai_api_key = "test_key"
+
+        mock_client = Mock()
+        mock_client.chat.completions.create.return_value = mock_openai_response
+        mock_openai.OpenAI.return_value = mock_client
+
+        prompt = "<script>alert('x')</script>Hi javascript:alert('x')"
+        ask_llm(prompt)
+
+        mock_client.chat.completions.create.assert_called_once_with(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": "Hi alert('x')"}],
+        )
+
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.anthropic")
     def test_ask_llm_claude_malformed_response(self, mock_anthropic, mock_env_settings):
         """Test Claude provider with malformed response"""
         mock_env_settings.llm_provider = "claude"
@@ -381,8 +423,8 @@ class TestLLMEdgeCases:
 
         assert "LLM error:" in result
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_ask_llm_openai_none_response(self, mock_openai, mock_env_settings):
         """Test OpenAI provider with None response content"""
         mock_env_settings.llm_provider = "openai"
@@ -399,22 +441,28 @@ class TestLLMEdgeCases:
 
         assert "LLM error:" in result
 
+
 class TestLLMParameterized:
-    @pytest.mark.parametrize("provider,expected_calls", [
-        ("claude", "anthropic"),
-        ("CLAUDE", "anthropic"),
-        ("Claude", "anthropic"),
-        ("openai", "openai"),
-        ("OPENAI", "openai"),
-        ("OpenAI", "openai"),
-        ("gpt", "openai"),
-        ("unknown", "openai"),
-        ("", "openai"),
-    ])
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.anthropic')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
-    def test_provider_routing(self, mock_openai, mock_anthropic, mock_env_settings, provider, expected_calls):
+    @pytest.mark.parametrize(
+        "provider,expected_calls",
+        [
+            ("claude", "anthropic"),
+            ("CLAUDE", "anthropic"),
+            ("Claude", "anthropic"),
+            ("openai", "openai"),
+            ("OPENAI", "openai"),
+            ("OpenAI", "openai"),
+            ("gpt", "openai"),
+            ("unknown", "openai"),
+            ("", "openai"),
+        ],
+    )
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.anthropic")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
+    def test_provider_routing(
+        self, mock_openai, mock_anthropic, mock_env_settings, provider, expected_calls
+    ):
         """Test that different provider names route to correct implementations"""
         mock_env_settings.llm_provider = provider
         mock_env_settings.anthropic_api_key = "claude_key"
@@ -428,7 +476,9 @@ class TestLLMParameterized:
             mock_anthropic.Anthropic.return_value = mock_client
         else:
             mock_openai_response = Mock()
-            mock_openai_response.choices = [Mock(message=Mock(content="OpenAI response"))]
+            mock_openai_response.choices = [
+                Mock(message=Mock(content="OpenAI response"))
+            ]
             mock_client = Mock()
             mock_client.chat.completions.create.return_value = mock_openai_response
             mock_openai.OpenAI.return_value = mock_client
@@ -442,19 +492,24 @@ class TestLLMParameterized:
             assert "OpenAI response" in result
             mock_openai.OpenAI.assert_called_once()
 
-    @pytest.mark.parametrize("prompt", [
-        "Simple prompt",
-        "",
-        "A" * 1000,
-        "Unicode: 世界 🌍",
-        "Special chars: @#$%^&*()",
-        "Multi\nline\nprompt",
-        "Tab\tcharacters",
-        "Quotes 'single' \"double\"",
-    ])
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
-    def test_various_prompt_types(self, mock_openai, mock_env_settings, prompt, mock_openai_response):
+    @pytest.mark.parametrize(
+        "prompt",
+        [
+            "Simple prompt",
+            "",
+            "A" * 1000,
+            "Unicode: 世界 🌍",
+            "Special chars: @#$%^&*()",
+            "Multi\nline\nprompt",
+            "Tab\tcharacters",
+            "Quotes 'single' \"double\"",
+        ],
+    )
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
+    def test_various_prompt_types(
+        self, mock_openai, mock_env_settings, prompt, mock_openai_response
+    ):
         """Test LLM with various prompt types and characters"""
         mock_env_settings.llm_provider = "openai"
         mock_env_settings.openai_api_key = "test_key"
@@ -467,13 +522,13 @@ class TestLLMParameterized:
 
         assert result == "OpenAI response text"
         mock_client.chat.completions.create.assert_called_once_with(
-            model="gpt-3.5-turbo",
-            messages=[{"role": "user", "content": prompt}]
+            model="gpt-3.5-turbo", messages=[{"role": "user", "content": prompt}]
         )
 
+
 class TestLLMStressAndPerformance:
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_multiple_sequential_calls(self, mock_openai, mock_env_settings):
         """Test multiple sequential LLM calls"""
         mock_env_settings.llm_provider = "openai"
@@ -500,27 +555,35 @@ class TestLLMStressAndPerformance:
             expected_index = i + 5
             assert LLM_QUERY_LOGS[i]["prompt"] == f"Prompt {expected_index}"
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.logger')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.logger")
     def test_error_logging(self, mock_logger, mock_env_settings):
         """Test that errors are properly logged"""
         mock_env_settings.llm_provider = "openai"
         mock_env_settings.openai_api_key = "test_key"
 
         # Mock import failure
-        with patch('adaptive_graph_of_thoughts.services.llm.openai', side_effect=ImportError("Module not found")):
+        with patch(
+            "adaptive_graph_of_thoughts.services.llm.openai",
+            side_effect=ImportError("Module not found"),
+        ):
             result = ask_llm("Test prompt")
 
             assert result == "LLM error: Module not found"
-            mock_logger.error.assert_called_once_with("LLM call failed: Module not found")
+            mock_logger.error.assert_called_once_with(
+                "LLM call failed: Module not found"
+            )
+
 
 class TestLLMIntegration:
     def test_llm_query_logs_global_state(self):
         """Test that LLM_QUERY_LOGS is properly managed as global state"""
         initial_length = len(LLM_QUERY_LOGS)
 
-        with patch('adaptive_graph_of_thoughts.services.llm.env_settings') as mock_env_settings:
-            with patch('adaptive_graph_of_thoughts.services.llm.openai') as mock_openai:
+        with patch(
+            "adaptive_graph_of_thoughts.services.llm.env_settings"
+        ) as mock_env_settings:
+            with patch("adaptive_graph_of_thoughts.services.llm.openai") as mock_openai:
                 mock_env_settings.llm_provider = "openai"
                 mock_env_settings.openai_api_key = "test_key"
 
@@ -535,9 +598,11 @@ class TestLLMIntegration:
                 assert len(LLM_QUERY_LOGS) == initial_length + 1
 
     @patch.dict(os.environ, {}, clear=True)
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
-    def test_environment_variable_defaults(self, mock_openai, mock_env_settings, mock_openai_response):
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
+    def test_environment_variable_defaults(
+        self, mock_openai, mock_env_settings, mock_openai_response
+    ):
         """Test default model values when environment variables are not set"""
         mock_env_settings.llm_provider = "openai"
         mock_env_settings.openai_api_key = "test_key"
@@ -549,14 +614,15 @@ class TestLLMIntegration:
         ask_llm("Test prompt")
 
         mock_client.chat.completions.create.assert_called_once_with(
-            model="gpt-3.5-turbo",
-            messages=[{"role": "user", "content": "Test prompt"}]
+            model="gpt-3.5-turbo", messages=[{"role": "user", "content": "Test prompt"}]
         )
 
-    @patch.dict(os.environ, {'CLAUDE_MODEL': '', 'OPENAI_MODEL': ''})
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
-    def test_empty_environment_variables(self, mock_openai, mock_env_settings, mock_openai_response):
+    @patch.dict(os.environ, {"CLAUDE_MODEL": "", "OPENAI_MODEL": ""})
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
+    def test_empty_environment_variables(
+        self, mock_openai, mock_env_settings, mock_openai_response
+    ):
         """Test behavior with empty environment variables"""
         mock_env_settings.llm_provider = "openai"
         mock_env_settings.openai_api_key = "test_key"
@@ -568,9 +634,9 @@ class TestLLMIntegration:
         ask_llm("Test prompt")
 
         mock_client.chat.completions.create.assert_called_once_with(
-            model="gpt-3.5-turbo",
-            messages=[{"role": "user", "content": "Test prompt"}]
+            model="gpt-3.5-turbo", messages=[{"role": "user", "content": "Test prompt"}]
         )
+
 
 def test_module_imports():
     """Test that all required modules can be imported without errors"""
@@ -578,6 +644,7 @@ def test_module_imports():
 
     assert callable(ask_llm)
     assert isinstance(LLM_QUERY_LOGS, list)
+
 
 def test_llm_query_logs_type():
     """Test that LLM_QUERY_LOGS is the correct type"""


### PR DESCRIPTION
## Summary
- sanitize user prompts before sending them to LLM
- support configurable token limit and API key checks
- adjust `load_with_overrides` signature
- update tests for new validation behavior

## Testing
- `poetry run ruff format src/adaptive_graph_of_thoughts/config.py`
- `poetry run ruff format src/adaptive_graph_of_thoughts/services/llm.py tests/unit/test_llm.py`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6857cc95eb98832aa990cd2773d9fa6d