### PR TITLE
Refactor validation limits

### DIFF
--- a/src/adaptive_graph_of_thoughts/config.py
+++ b/src/adaptive_graph_of_thoughts/config.py
@@ -39,22 +39,59 @@ env_settings = EnvSettings()
 _config_lock = threading.RLock()
 
 
+class ConfigLimits:
+    """Centralized configuration limits used for validation."""
+
+    LEARNING_RATE_MIN = 0.0
+    LEARNING_RATE_MAX = 1.0
+    BATCH_SIZE_MIN = 1
+    BATCH_SIZE_MAX = 10_000
+    MAX_STEPS_MIN = 1
+    MAX_STEPS_MAX = 1_000_000
+
+    # Database limits
+    MAX_QUERY_LENGTH = 100_000
+    MAX_BATCH_SIZE = 10_000
+    CONNECTION_TIMEOUT = 30
+
+    # LLM limits
+    MAX_PROMPT_LENGTH = 100_000
+    MAX_RESPONSE_LENGTH = 50_000
+
+
 def validate_learning_rate(lr: float) -> None:
     """Validate learning rate is in valid range."""
-    if not isinstance(lr, (int, float)) or lr <= 0 or lr > 1.0:
-        raise ValueError(f"Learning rate must be between 0 and 1.0, got {lr}")
+    if not isinstance(lr, (int, float)):
+        raise TypeError(f"Learning rate must be a number, got {type(lr)}")
+    if not (ConfigLimits.LEARNING_RATE_MIN < lr <= ConfigLimits.LEARNING_RATE_MAX):
+        raise ValueError(
+            f"Learning rate must be between {ConfigLimits.LEARNING_RATE_MIN} and "
+            f"{ConfigLimits.LEARNING_RATE_MAX}, got {lr}"
+        )
 
 
 def validate_batch_size(batch_size: int) -> None:
-    """Validate batch size is positive integer."""
-    if not isinstance(batch_size, int) or batch_size <= 0:
-        raise ValueError(f"Batch size must be a positive integer, got {batch_size}")
+    """Validate batch size is within allowed limits."""
+    if not isinstance(batch_size, int):
+        raise TypeError(f"Batch size must be an integer, got {type(batch_size)}")
+    if not (
+        ConfigLimits.BATCH_SIZE_MIN <= batch_size <= ConfigLimits.BATCH_SIZE_MAX
+    ):
+        raise ValueError(
+            f"Batch size must be between {ConfigLimits.BATCH_SIZE_MIN} and "
+            f"{ConfigLimits.BATCH_SIZE_MAX}, got {batch_size}"
+        )
 
 
 def validate_max_steps(max_steps: int) -> None:
-    """Validate max steps is positive integer."""
-    if not isinstance(max_steps, int) or max_steps <= 0:
-        raise ValueError(f"Max steps must be a positive integer, got {max_steps}")
+    """Validate max steps is within allowed limits."""
+    if not isinstance(max_steps, int):
+        raise TypeError(f"Max steps must be an integer, got {type(max_steps)}")
+    if not (ConfigLimits.MAX_STEPS_MIN <= max_steps <= ConfigLimits.MAX_STEPS_MAX):
+        raise ValueError(
+            f"Max steps must be between {ConfigLimits.MAX_STEPS_MIN} and "
+            f"{ConfigLimits.MAX_STEPS_MAX}, got {max_steps}"
+        )
 
 
 def validate_config_schema(_config_data: dict) -> bool:
@@ -317,12 +354,8 @@ class LegacyConfig:
         cls,
         base_file: str,
         override_file: str,
-    def load_with_overrides(
-        base_path: Path,
-        override_path: Path,
         *,
         _loading_stack: Optional[set[Path]] = None,
-    ) -> Config:
     ) -> "LegacyConfig":
         """Load config with hierarchical overrides.
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -98,14 +98,14 @@ class TestValidationFunctions:
         validate_learning_rate(0.001)
 
     def test_validate_learning_rate_invalid(self):
-        """Test invalid learning rates raise ValueError."""
-        with pytest.raises(ValueError, match="Learning rate must be between 0 and 1.0"):
+        """Test invalid learning rates raise errors."""
+        with pytest.raises(ValueError, match="Learning rate must be between 0.0 and 1.0"):
             validate_learning_rate(0)
-        with pytest.raises(ValueError, match="Learning rate must be between 0 and 1.0"):
+        with pytest.raises(ValueError, match="Learning rate must be between 0.0 and 1.0"):
             validate_learning_rate(-0.1)
-        with pytest.raises(ValueError, match="Learning rate must be between 0 and 1.0"):
+        with pytest.raises(ValueError, match="Learning rate must be between 0.0 and 1.0"):
             validate_learning_rate(1.1)
-        with pytest.raises(ValueError, match="Learning rate must be between 0 and 1.0"):
+        with pytest.raises(TypeError, match="Learning rate must be a number"):
             validate_learning_rate("0.1")
 
     def test_validate_batch_size_valid(self):
@@ -115,14 +115,14 @@ class TestValidationFunctions:
         validate_batch_size(1000)
 
     def test_validate_batch_size_invalid(self):
-        """Test invalid batch sizes raise ValueError."""
-        with pytest.raises(ValueError, match="Batch size must be a positive integer"):
+        """Test invalid batch sizes raise errors."""
+        with pytest.raises(ValueError, match="Batch size must be between"):
             validate_batch_size(0)
-        with pytest.raises(ValueError, match="Batch size must be a positive integer"):
+        with pytest.raises(ValueError, match="Batch size must be between"):
             validate_batch_size(-1)
-        with pytest.raises(ValueError, match="Batch size must be a positive integer"):
+        with pytest.raises(TypeError, match="Batch size must be an integer"):
             validate_batch_size(1.5)
-        with pytest.raises(ValueError, match="Batch size must be a positive integer"):
+        with pytest.raises(TypeError, match="Batch size must be an integer"):
             validate_batch_size("32")
 
     def test_validate_max_steps_valid(self):
@@ -132,14 +132,14 @@ class TestValidationFunctions:
         validate_max_steps(10000)
 
     def test_validate_max_steps_invalid(self):
-        """Test invalid max steps raise ValueError."""
-        with pytest.raises(ValueError, match="Max steps must be a positive integer"):
+        """Test invalid max steps raise errors."""
+        with pytest.raises(ValueError, match="Max steps must be between"):
             validate_max_steps(0)
-        with pytest.raises(ValueError, match="Max steps must be a positive integer"):
+        with pytest.raises(ValueError, match="Max steps must be between"):
             validate_max_steps(-1)
-        with pytest.raises(ValueError, match="Max steps must be a positive integer"):
+        with pytest.raises(TypeError, match="Max steps must be an integer"):
             validate_max_steps(1.5)
-        with pytest.raises(ValueError, match="Max steps must be a positive integer"):
+        with pytest.raises(TypeError, match="Max steps must be an integer"):
             validate_max_steps("1000")
 
     def test_validate_config_schema(self):


### PR DESCRIPTION
## Summary
- centralize numeric limits in `ConfigLimits`
- update validation helpers to use new constants
- adjust tests for stricter type checking
- fix malformed `load_with_overrides` definition

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6857cca423f4832a8359364aac2c4c40