### PR TITLE
Add server readiness checks to tool APIs

### DIFF
--- a/src/adaptive_graph_of_thoughts/api/routes/tools.py
+++ b/src/adaptive_graph_of_thoughts/api/routes/tools.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 
 TOOLS_LIST = [
     {
@@ -27,6 +27,10 @@ tools_router = APIRouter()
 
 
 @tools_router.get("/tools", tags=["Tools"])
-async def list_tools() -> dict[str, list[dict[str, str]]]:
-    """Return a list of available MCP tools."""
+async def list_tools(request: Request) -> dict[str, list[dict[str, str]]]:
+    """Return a list of available MCP tools only when ready."""
+    got_processor = getattr(request.app.state, "got_processor", None)
+    if got_processor and not getattr(got_processor, "models_loaded", True):
+        return {"tools": []}
+
     return {"tools": TOOLS_LIST}

--- a/src/adaptive_graph_of_thoughts/domain/services/got_processor.py
+++ b/src/adaptive_graph_of_thoughts/domain/services/got_processor.py
@@ -94,11 +94,18 @@ class GoTProcessor:
         Initializes a GoTProcessor instance with the provided settings.
         """
         self.settings = settings
+        # Flag used by health checks to determine if the processor is ready to
+        # handle requests. It starts as False and is set to True once all stages
+        # (and implicitly any required models) are loaded.
+        self.models_loaded = False
+
         logger.info("Initializing GoTProcessor")
         self.stages = self._initialize_stages()
         logger.info(
             f"GoTProcessor initialized with {len(self.stages)} configured and enabled stages."
         )
+        # Mark the processor as ready for use
+        self.models_loaded = True
 
     def _initialize_stages(self) -> list[BaseStage]:
         """

--- a/src/adaptive_graph_of_thoughts/server_factory.py
+++ b/src/adaptive_graph_of_thoughts/server_factory.py
@@ -194,6 +194,16 @@ class MCPServerFactory:
                     params, request_id, got_processor
                 )
 
+            elif method == "listTools":
+                return await MCPServerFactory._handle_list_tools(
+                    request_id, got_processor
+                )
+
+            elif method == "callTool":
+                return await MCPServerFactory._handle_call_tool(
+                    params, request_id, got_processor
+                )
+
             elif method == "shutdown":
                 await MCPServerFactory._handle_shutdown(params, request_id)
                 return JSONRPCResponse(id=request_id, result=None)
@@ -281,3 +291,74 @@ class MCPServerFactory:
         """Handle shutdown request."""
         logger.info("MCP Shutdown request received via STDIO.")
         # Note: The actual shutdown will be handled by the main loop
+
+    @staticmethod
+    async def _handle_list_tools(
+        request_id: Optional[str], got_processor: "GoTProcessor"
+    ) -> JSONRPCResponse:
+        """Return available tools if the processor is ready."""
+        if not getattr(got_processor, "models_loaded", True):
+            return JSONRPCResponse(id=request_id, result=[])
+
+        tools = [
+            {
+                "name": "graph_reasoning",
+                "description": "Perform graph-based reasoning",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "confidence_threshold": {"type": "number", "default": 0.7},
+                    },
+                },
+            }
+        ]
+        return JSONRPCResponse(id=request_id, result=tools)
+
+    @staticmethod
+    async def _handle_call_tool(
+        params: dict[str, Any], request_id: Optional[str], got_processor: "GoTProcessor"
+    ) -> JSONRPCResponse:
+        """Execute a tool call with basic error handling."""
+
+        if not getattr(got_processor, "models_loaded", True):
+            return JSONRPCResponse(
+                id=request_id,
+                result=[{"type": "text", "text": "Server is still initializing. Please wait..."}],
+            )
+
+        name = params.get("name")
+        arguments = params.get("arguments", {})
+
+        try:
+            if name == "graph_reasoning":
+                query = arguments.get("query")
+                if not query:
+                    return create_jsonrpc_error(
+                        request_id=request_id,
+                        code=-32602,
+                        message="Missing 'query' argument",
+                    )
+
+                conf = arguments.get("confidence_threshold", 0.7)
+                result = await got_processor.process_query(
+                    query=query,
+                    operational_params={"confidence_threshold": conf},
+                )
+                answer = result.final_answer or ""
+                return JSONRPCResponse(
+                    id=request_id,
+                    result=[{"type": "text", "text": answer}],
+                )
+
+            return create_jsonrpc_error(
+                request_id=request_id,
+                code=-32601,
+                message=f"Tool '{name}' not found",
+            )
+        except Exception as e:  # pragma: no cover - best effort
+            logger.error(f"Tool execution failed: {e}")
+            return JSONRPCResponse(
+                id=request_id,
+                result=[{"type": "text", "text": f"Error: {e}"}],
+            )


### PR DESCRIPTION
## Summary
- keep track of model loading state in `GoTProcessor`
- hide tools until the processor is ready
- expose new `listTools` and `callTool` handlers for STDIO JSON‑RPC server

## Testing
- `poetry run ruff check src/adaptive_graph_of_thoughts/api/routes/tools.py src/adaptive_graph_of_thoughts/domain/services/got_processor.py src/adaptive_graph_of_thoughts/server_factory.py`
- `make test`
- `poetry run mypy src`
- `poetry run pyright src`

------
https://chatgpt.com/codex/tasks/task_e_6857e36f5e0c832a820459b63384c061