### PR TITLE
Add timeout decorator and AdaptiveGraphServer

### DIFF
--- a/src/adaptive_graph_of_thoughts/domain/services/__init__.py
+++ b/src/adaptive_graph_of_thoughts/domain/services/__init__.py
@@ -2,6 +2,13 @@
 
 from .exceptions import ProcessingError, StageExecutionError
 from .got_processor import GoTProcessor, GoTProcessorSessionData
+from .graph_server import AdaptiveGraphServer
 
 # Control what gets imported with 'from .services import *'
-__all__ = ["GoTProcessor", "GoTProcessorSessionData", "ProcessingError", "StageExecutionError"]
+__all__ = [
+    "GoTProcessor",
+    "GoTProcessorSessionData",
+    "AdaptiveGraphServer",
+    "ProcessingError",
+    "StageExecutionError",
+]

--- a/src/adaptive_graph_of_thoughts/domain/services/graph_server.py
+++ b/src/adaptive_graph_of_thoughts/domain/services/graph_server.py
@@ -1,0 +1,45 @@
+import asyncio
+import logging
+from functools import wraps
+from typing import Any
+
+
+def with_timeout(seconds: float):
+    """Decorator to add timeout to async functions"""
+
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            try:
+                return await asyncio.wait_for(
+                    func(*args, **kwargs),
+                    timeout=seconds,
+                )
+            except asyncio.TimeoutError:
+                logging.warning(f"{func.__name__} timed out after {seconds}s")
+                raise
+
+        return wrapper
+
+    return decorator
+
+
+class AdaptiveGraphServer:
+    """Simplified graph server wrapper."""
+
+    def _process_reasoning_sync(self, query: str, confidence_threshold: float) -> str:
+        """Placeholder for CPU-bound reasoning logic."""
+        raise NotImplementedError
+
+    @with_timeout(30.0)  # 30 second timeout
+    async def process_reasoning_async(self, arguments: dict[str, Any]) -> str:
+        """Process graph reasoning with timeout"""
+        query = arguments.get("query", "")
+        confidence_threshold = arguments.get("confidence_threshold", 0.7)
+
+        result = await asyncio.to_thread(
+            self._process_reasoning_sync,
+            query,
+            confidence_threshold,
+        )
+        return result


### PR DESCRIPTION
## Summary
- add `AdaptiveGraphServer` implementing async reasoning with a timeout
- expose it from the services package

## Testing
- `ruff format src/adaptive_graph_of_thoughts/domain/services/graph_server.py`
- `ruff check src/adaptive_graph_of_thoughts/domain/services/graph_server.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857e388e624832aa102cfd21211a459