### PR TITLE
Implement resource monitor

### DIFF
--- a/src/adaptive_graph_of_thoughts/app_setup.py
+++ b/src/adaptive_graph_of_thoughts/app_setup.py
@@ -34,6 +34,7 @@ from adaptive_graph_of_thoughts.config import (
 from adaptive_graph_of_thoughts.domain.services.got_processor import (
     GoTProcessor,
 )
+from adaptive_graph_of_thoughts.services.resource_monitor import ResourceMonitor
 from adaptive_graph_of_thoughts.services.llm import LLM_QUERY_LOGS, ask_llm
 
 security = HTTPBasic()
@@ -159,7 +160,10 @@ def create_app() -> FastAPI:
     templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
 
     # Store GoTProcessor instance on app.state
-    app.state.got_processor = GoTProcessor(settings=settings)
+    resource_monitor = ResourceMonitor()
+    app.state.got_processor = GoTProcessor(
+        settings=settings, resource_monitor=resource_monitor
+    )
     logger.info("GoTProcessor instance created and attached to app state.")
 
     # Process allowed origins from settings

--- a/src/adaptive_graph_of_thoughts/server_factory.py
+++ b/src/adaptive_graph_of_thoughts/server_factory.py
@@ -20,6 +20,7 @@ from adaptive_graph_of_thoughts.api.schemas import (
     create_jsonrpc_error,
 )
 from adaptive_graph_of_thoughts.config import settings
+from adaptive_graph_of_thoughts.services.resource_monitor import ResourceMonitor
 
 # Using lazy imports to avoid circular dependencies
 
@@ -78,7 +79,8 @@ class MCPServerFactory:
         )
 
         # Initialize GoT processor
-        got_processor = GoTProcessor(settings=settings)
+        resource_monitor = ResourceMonitor()
+        got_processor = GoTProcessor(settings=settings, resource_monitor=resource_monitor)
         read_transport: Optional[asyncio.Transport] = None
 
         try:

--- a/src/adaptive_graph_of_thoughts/services/resource_monitor.py
+++ b/src/adaptive_graph_of_thoughts/services/resource_monitor.py
@@ -1,0 +1,30 @@
+import asyncio
+from typing import Optional
+
+import psutil
+from loguru import logger
+
+
+class ResourceMonitor:
+    """Monitor system resources and enforce simple usage limits."""
+
+    def __init__(self, max_memory_mb: int = 1024, max_cpu_percent: float = 80.0) -> None:
+        self.max_memory_mb = max_memory_mb
+        self.max_cpu_percent = max_cpu_percent
+
+    async def check_resources(self) -> bool:
+        """Return False if current usage exceeds configured limits."""
+        try:
+            memory_mb = psutil.virtual_memory().used / (1024 * 1024)
+            if memory_mb > self.max_memory_mb:
+                logger.warning(f"Memory usage high: {memory_mb:.1f}MB")
+                return False
+
+            cpu_percent = psutil.cpu_percent(interval=1)
+            if cpu_percent > self.max_cpu_percent:
+                logger.warning(f"CPU usage high: {cpu_percent:.1f}%")
+                return False
+            return True
+        except Exception as exc:  # pragma: no cover - best effort
+            logger.error(f"Resource check failed: {exc}")
+            return True


### PR DESCRIPTION
## Summary
- create `ResourceMonitor` service for memory/CPU checks
- inject resource monitor into `GoTProcessor`
- halt processing when resource limits are exceeded
- initialize monitor in app setup and STDIO server

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857e3df2e08832a8f57ea0657caaec0