### PR TITLE
Fix test linter issues

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -21,6 +21,5 @@
     "reportUnusedVariable": false,
     "reportDuplicateImport": true,
     "reportGeneralTypeIssues": false,
--    "reportPrivateImportUsage": false,
-+    "reportPrivateImportUsage": false
+    "reportPrivateImportUsage": false
 }

--- a/src/adaptive_graph_of_thoughts/validation.py
+++ b/src/adaptive_graph_of_thoughts/validation.py
@@ -20,7 +20,7 @@ class QueryValidation(BaseModel):
         
         for pattern in dangerous_patterns:
             if re.search(pattern, v, re.IGNORECASE | re.DOTALL):
-                raise ValueError(f"Query contains potentially dangerous content")
+                raise ValueError("Query contains potentially dangerous content")
         
         return v.strip()
     

--- a/tests/integration/api/test_stdio_mcp.py
+++ b/tests/integration/api/test_stdio_mcp.py
@@ -77,7 +77,10 @@ def test_stdio_initialize(stdio_process):
     assert "mcp_version" in result_data and isinstance(result_data["mcp_version"], str)
 
 
-@pytest.mark.parametrize("query", ["test question"])
+@pytest.mark.parametrize(
+    "query",
+    ["test question"],
+)
 def test_stdio_call_tool(stdio_process, query):
     """Test calling the asr_got_query tool over STDIO."""
     request = {

--- a/tests/integration/stages/test_integration_initialization_stage.py
+++ b/tests/integration/stages/test_integration_initialization_stage.py
@@ -10,16 +10,19 @@ pytestmark = pytest.mark.skipif(
 from dataclasses import dataclass
 import sys
 import types
-from typing import Generator
+from typing import ClassVar, Generator
 
 class DummyDefaultParams:
-    initial_confidence = [0.9, 0.9, 0.9, 0.9]
-    initial_layer = "root_layer"
+    initial_confidence: ClassVar[list[float]] = [0.9, 0.9, 0.9, 0.9]
+    initial_layer: ClassVar[str] = "root_layer"
+
+
+DummyASRGot = type("obj", (), {"default_parameters": DummyDefaultParams()})
 
 
 @dataclass
 class DummySettings:
-    asr_got: type = type("obj", (), {"default_parameters": DummyDefaultParams()})
+    asr_got: type = DummyASRGot
 
 @pytest.fixture(scope="module", autouse=True)
 def stub_modules(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
@@ -582,7 +585,7 @@ async def test_initialization_stage_concurrent_execution_safety(settings_instanc
 
     # Execute multiple times concurrently
     tasks = []
-    for i in range(5):
+    for _ in range(5):
         session_data = GoTProcessorSessionData(query=query)
         tasks.append(stage.execute(current_session_data=session_data))
     

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,6 +1,16 @@
 import pytest
 from fastapi.testclient import TestClient
 from src.adaptive_graph_of_thoughts.app_setup import create_app
+import re
+
+
+def validate_identifier(identifier: str, allowed_labels: set[str]) -> str:
+    """Validate Neo4j identifier to prevent injection attacks."""
+    if not re.match(r"^[A-Za-z][A-Za-z0-9_]*$", identifier):
+        raise ValueError("Invalid identifier")
+    if identifier not in allowed_labels:
+        raise ValueError("Identifier not allowed")
+    return identifier
 
 class TestSecurity:
     def test_authentication_required(self):

--- a/tests/unit/api/test_nlq.py
+++ b/tests/unit/api/test_nlq.py
@@ -658,7 +658,7 @@ def test_nlq_endpoint_llm_query_logs_management(client, auth_headers, monkeypatc
     
     def tracking_llm(prompt: str) -> str:
         if "Convert" in prompt:
-            return f"MATCH (n) RETURN n // Query for test"
+            return "MATCH (n) RETURN n // Query for test"
         return "Test response"
 
     monkeypatch.setattr("adaptive_graph_of_thoughts.services.llm.ask_llm", tracking_llm)

--- a/tests/unit/config/test_config_validation.py
+++ b/tests/unit/config/test_config_validation.py
@@ -57,7 +57,10 @@ def test_minimal_config(minimal_config):
     assert "google_scholar" not in config_data_to_validate
 
 
-@pytest.mark.parametrize("missing_key", ["app", "asr_got", "mcp_settings"])
+@pytest.mark.parametrize(
+    "missing_key",
+    ["app", "asr_got", "mcp_settings"],
+)
 def test_missing_keys(tmp_path, base_config_dict, missing_key):
     cfg = copy.deepcopy(base_config_dict)
     cfg.pop(missing_key)
@@ -120,7 +123,10 @@ def test_unreadable_file(tmp_path):
         file_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
 
 
-@pytest.mark.parametrize("port", [1, 65535])
+@pytest.mark.parametrize(
+    "port",
+    [1, 65535],
+)
 def test_boundary_values(tmp_path, port):
     cfg = copy.deepcopy(base_config_dict)
     cfg["app"]["port"] = port

--- a/tests/unit/services/test_llm.py
+++ b/tests/unit/services/test_llm.py
@@ -9,12 +9,20 @@ from dataclasses import asdict
 # Import the LLM service components from the correct path
 import sys
 import os
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../../git/src'))
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../git/src"))
 
 from adaptive_graph_of_thoughts.services.llm import (
-    LLMConfig, LLMService, LLMProvider, OpenAIProvider, AnthropicProvider,
-    LLMException, TokenLimitExceeded, RateLimitExceeded
+    LLMConfig,
+    LLMService,
+    LLMProvider,
+    OpenAIProvider,
+    AnthropicProvider,
+    LLMException,
+    TokenLimitExceeded,
+    RateLimitExceeded,
 )
+
 
 # Test fixtures for configuration and mock data
 @pytest.fixture
@@ -28,8 +36,9 @@ def base_config():
         temperature=0.7,
         timeout=30.0,
         max_retries=3,
-        retry_delay=1.0
+        retry_delay=1.0,
     )
+
 
 @pytest.fixture
 def anthropic_config():
@@ -39,8 +48,9 @@ def anthropic_config():
         model="claude-3-sonnet-20240229",
         api_key="test-anthropic-key",
         max_tokens=2000,
-        temperature=0.5
+        temperature=0.5,
     )
+
 
 @pytest.fixture
 def sample_messages():
@@ -49,13 +59,15 @@ def sample_messages():
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "Hello, how are you?"},
         {"role": "assistant", "content": "I'm doing well, thank you!"},
-        {"role": "user", "content": "Can you help me with coding?"}
+        {"role": "user", "content": "Can you help me with coding?"},
     ]
+
 
 @pytest.fixture
 def simple_messages():
     """Simple user message for basic testing."""
     return [{"role": "user", "content": "Hello world"}]
+
 
 @pytest.fixture
 def mock_openai_response():
@@ -63,48 +75,46 @@ def mock_openai_response():
     mock_choice = MagicMock()
     mock_choice.message.content = "I'm doing well, thank you for asking!"
     mock_choice.finish_reason = "stop"
-    
+
     mock_usage = MagicMock()
     mock_usage.prompt_tokens = 15
     mock_usage.completion_tokens = 10
     mock_usage.total_tokens = 25
-    
+
     mock_response = MagicMock()
     mock_response.choices = [mock_choice]
     mock_response.usage = mock_usage
     mock_response.model = "gpt-4"
-    
+
     return mock_response
+
 
 @pytest.fixture
 def mock_anthropic_response():
     """Mock response from Anthropic API."""
     mock_content = MagicMock()
     mock_content.text = "Hello! I'm Claude, nice to meet you."
-    
+
     mock_usage = MagicMock()
     mock_usage.input_tokens = 12
     mock_usage.output_tokens = 8
-    
+
     mock_response = MagicMock()
     mock_response.content = [mock_content]
     mock_response.usage = mock_usage
     mock_response.model = "claude-3-sonnet-20240229"
     mock_response.stop_reason = "end_turn"
-    
+
     return mock_response
+
 
 class TestLLMConfig:
     """Test LLMConfig dataclass functionality."""
-    
+
     def test_config_initialization_with_defaults(self):
         """Test LLMConfig initialization with default values."""
-        config = LLMConfig(
-            provider="openai",
-            model="gpt-4",
-            api_key="test-key"
-        )
-        
+        config = LLMConfig(provider="openai", model="gpt-4", api_key="test-key")
+
         assert config.provider == "openai"
         assert config.model == "gpt-4"
         assert config.api_key == "test-key"
@@ -115,7 +125,7 @@ class TestLLMConfig:
         assert config.retry_delay == 1.0
         assert config.base_url is None
         assert config.additional_headers == {}
-    
+
     def test_config_initialization_with_custom_values(self):
         """Test LLMConfig initialization with custom values."""
         headers = {"Custom-Header": "test-value"}
@@ -129,9 +139,9 @@ class TestLLMConfig:
             max_retries=5,
             retry_delay=2.0,
             base_url="https://custom.api.endpoint",
-            additional_headers=headers
+            additional_headers=headers,
         )
-        
+
         assert config.provider == "anthropic"
         assert config.model == "claude-3-opus-20240229"
         assert config.max_tokens == 2000
@@ -141,16 +151,16 @@ class TestLLMConfig:
         assert config.retry_delay == 2.0
         assert config.base_url == "https://custom.api.endpoint"
         assert config.additional_headers == headers
-    
+
     def test_config_serialization(self, base_config):
         """Test LLMConfig can be serialized to dict."""
         config_dict = asdict(base_config)
-        
+
         assert isinstance(config_dict, dict)
         assert config_dict["provider"] == "openai"
         assert config_dict["model"] == "gpt-4"
         assert config_dict["api_key"] == "test-api-key-12345"
-    
+
     def test_config_edge_case_values(self):
         """Test LLMConfig with edge case values."""
         config = LLMConfig(
@@ -161,9 +171,9 @@ class TestLLMConfig:
             temperature=0.0,  # Minimum temperature
             timeout=0.1,  # Very short timeout
             max_retries=0,  # No retries
-            retry_delay=0.0  # No delay
+            retry_delay=0.0,  # No delay
         )
-        
+
         assert config.api_key == ""
         assert config.max_tokens == 1
         assert config.temperature == 0.0
@@ -171,424 +181,514 @@ class TestLLMConfig:
         assert config.max_retries == 0
         assert config.retry_delay == 0.0
 
+
 class TestLLMExceptions:
     """Test custom LLM exception classes."""
-    
+
     def test_llm_exception_basic(self):
         """Test basic LLMException functionality."""
         error_msg = "Test error message"
         exception = LLMException(error_msg)
-        
+
         assert str(exception) == error_msg
         assert isinstance(exception, Exception)
-    
+
     def test_token_limit_exceeded_exception(self):
         """Test TokenLimitExceeded exception."""
         error_msg = "Token limit of 1000 exceeded"
         exception = TokenLimitExceeded(error_msg)
-        
+
         assert str(exception) == error_msg
         assert isinstance(exception, LLMException)
         assert isinstance(exception, Exception)
-    
+
     def test_rate_limit_exceeded_exception(self):
         """Test RateLimitExceeded exception."""
         error_msg = "Rate limit of 100 requests per minute exceeded"
         exception = RateLimitExceeded(error_msg)
-        
+
         assert str(exception) == error_msg
         assert isinstance(exception, LLMException)
         assert isinstance(exception, Exception)
-    
+
     def test_exception_inheritance_chain(self):
         """Test exception inheritance chain is correct."""
         assert issubclass(TokenLimitExceeded, LLMException)
         assert issubclass(RateLimitExceeded, LLMException)
         assert issubclass(LLMException, Exception)
-    
+
     def test_exception_with_complex_data(self):
         """Test exceptions can handle complex error data."""
         error_data = {
             "error_code": "RATE_LIMIT_EXCEEDED",
             "retry_after": 60,
-            "request_id": "req_123456"
+            "request_id": "req_123456",
         }
         exception = RateLimitExceeded(f"Rate limit exceeded: {json.dumps(error_data)}")
-        
+
         error_str = str(exception)
         assert "RATE_LIMIT_EXCEEDED" in error_str
         assert "retry_after" in error_str
         assert "req_123456" in error_str
 
+
 class TestOpenAIProvider:
     """Test OpenAI provider implementation."""
-    
+
     @pytest.fixture
     def openai_provider(self, base_config):
         """Create OpenAI provider instance for testing."""
-        with patch('adaptive_graph_of_thoughts.services.llm.AsyncOpenAI') as mock_openai:
+        with patch(
+            "adaptive_graph_of_thoughts.services.llm.AsyncOpenAI"
+        ) as mock_openai:
             provider = OpenAIProvider(base_config)
             provider.client = AsyncMock()
             return provider
-    
+
     def test_openai_provider_initialization(self, base_config):
         """Test OpenAI provider initialization."""
-        with patch('adaptive_graph_of_thoughts.services.llm.AsyncOpenAI') as mock_openai:
+        with patch(
+            "adaptive_graph_of_thoughts.services.llm.AsyncOpenAI"
+        ) as mock_openai:
             provider = OpenAIProvider(base_config)
-            
+
             assert provider.config == base_config
             mock_openai.assert_called_once_with(
                 api_key=base_config.api_key,
                 base_url=base_config.base_url,
                 timeout=base_config.timeout,
                 max_retries=base_config.max_retries,
-                default_headers=base_config.additional_headers
+                default_headers=base_config.additional_headers,
             )
-    
+
     @pytest.mark.asyncio
-    async def test_generate_completion_success(self, openai_provider, simple_messages, mock_openai_response):
+    async def test_generate_completion_success(
+        self, openai_provider, simple_messages, mock_openai_response
+    ):
         """Test successful completion generation with OpenAI."""
-        openai_provider.client.chat.completions.create.return_value = mock_openai_response
-        
+        openai_provider.client.chat.completions.create.return_value = (
+            mock_openai_response
+        )
+
         result = await openai_provider.generate_completion(simple_messages)
-        
+
         assert result["content"] == "I'm doing well, thank you for asking!"
         assert result["usage"]["total_tokens"] == 25
         assert result["usage"]["prompt_tokens"] == 15
         assert result["usage"]["completion_tokens"] == 10
         assert result["model"] == "gpt-4"
         assert result["finish_reason"] == "stop"
-        
+
         openai_provider.client.chat.completions.create.assert_called_once_with(
             model=openai_provider.config.model,
             messages=simple_messages,
             max_tokens=openai_provider.config.max_tokens,
-            temperature=openai_provider.config.temperature
+            temperature=openai_provider.config.temperature,
         )
-    
+
     @pytest.mark.asyncio
-    async def test_generate_completion_with_kwargs(self, openai_provider, simple_messages, mock_openai_response):
+    async def test_generate_completion_with_kwargs(
+        self, openai_provider, simple_messages, mock_openai_response
+    ):
         """Test completion generation with additional kwargs."""
-        openai_provider.client.chat.completions.create.return_value = mock_openai_response
-        
+        openai_provider.client.chat.completions.create.return_value = (
+            mock_openai_response
+        )
+
         kwargs = {"top_p": 0.9, "frequency_penalty": 0.5}
         result = await openai_provider.generate_completion(simple_messages, **kwargs)
-        
+
         assert result["content"] == "I'm doing well, thank you for asking!"
-        
+
         openai_provider.client.chat.completions.create.assert_called_once_with(
             model=openai_provider.config.model,
             messages=simple_messages,
             max_tokens=openai_provider.config.max_tokens,
             temperature=openai_provider.config.temperature,
             top_p=0.9,
-            frequency_penalty=0.5
+            frequency_penalty=0.5,
         )
-    
+
     @pytest.mark.asyncio
-    async def test_generate_completion_token_limit_error(self, openai_provider, simple_messages):
+    async def test_generate_completion_token_limit_error(
+        self, openai_provider, simple_messages
+    ):
         """Test completion generation with token limit error."""
         error_msg = "Token limit exceeded for this request"
-        openai_provider.client.chat.completions.create.side_effect = Exception(error_msg)
-        
+        openai_provider.client.chat.completions.create.side_effect = Exception(
+            error_msg
+        )
+
         with pytest.raises(TokenLimitExceeded, match="Token limit exceeded"):
             await openai_provider.generate_completion(simple_messages)
-    
+
     @pytest.mark.asyncio
-    async def test_generate_completion_rate_limit_error(self, openai_provider, simple_messages):
+    async def test_generate_completion_rate_limit_error(
+        self, openai_provider, simple_messages
+    ):
         """Test completion generation with rate limit error."""
         error_msg = "Rate limit exceeded. Please try again later"
-        openai_provider.client.chat.completions.create.side_effect = Exception(error_msg)
-        
+        openai_provider.client.chat.completions.create.side_effect = Exception(
+            error_msg
+        )
+
         with pytest.raises(RateLimitExceeded, match="Rate limit exceeded"):
             await openai_provider.generate_completion(simple_messages)
-    
+
     @pytest.mark.asyncio
-    async def test_generate_completion_generic_error(self, openai_provider, simple_messages):
+    async def test_generate_completion_generic_error(
+        self, openai_provider, simple_messages
+    ):
         """Test completion generation with generic error."""
         error_msg = "Network connection failed"
-        openai_provider.client.chat.completions.create.side_effect = Exception(error_msg)
-        
+        openai_provider.client.chat.completions.create.side_effect = Exception(
+            error_msg
+        )
+
         with pytest.raises(LLMException, match="OpenAI API error"):
             await openai_provider.generate_completion(simple_messages)
-    
+
     @pytest.mark.asyncio
-    async def test_generate_streaming_completion_success(self, openai_provider, simple_messages):
+    async def test_generate_streaming_completion_success(
+        self, openai_provider, simple_messages
+    ):
         """Test successful streaming completion generation."""
         # Mock streaming response chunks
         mock_chunks = [
-            MagicMock(choices=[MagicMock(delta=MagicMock(content="Hello"), finish_reason=None)]),
-            MagicMock(choices=[MagicMock(delta=MagicMock(content=" world"), finish_reason=None)]),
-            MagicMock(choices=[MagicMock(delta=MagicMock(content="!"), finish_reason="stop")])
+            MagicMock(
+                choices=[
+                    MagicMock(delta=MagicMock(content="Hello"), finish_reason=None)
+                ]
+            ),
+            MagicMock(
+                choices=[
+                    MagicMock(delta=MagicMock(content=" world"), finish_reason=None)
+                ]
+            ),
+            MagicMock(
+                choices=[MagicMock(delta=MagicMock(content="!"), finish_reason="stop")]
+            ),
         ]
-        
+
         async def mock_stream():
             for chunk in mock_chunks:
                 yield chunk
-        
+
         openai_provider.client.chat.completions.create.return_value = mock_stream()
-        
+
         results = []
-        async for chunk in openai_provider.generate_streaming_completion(simple_messages):
+        async for chunk in openai_provider.generate_streaming_completion(
+            simple_messages
+        ):
             results.append(chunk)
-        
+
         assert len(results) == 3
         assert results[0]["content"] == "Hello"
         assert results[1]["content"] == " world"
         assert results[2]["content"] == "!"
         assert results[2]["finish_reason"] == "stop"
-        
+
         openai_provider.client.chat.completions.create.assert_called_once_with(
             model=openai_provider.config.model,
             messages=simple_messages,
             max_tokens=openai_provider.config.max_tokens,
             temperature=openai_provider.config.temperature,
-            stream=True
+            stream=True,
         )
-    
+
     @pytest.mark.asyncio
-    async def test_generate_streaming_completion_empty_content(self, openai_provider, simple_messages):
+    async def test_generate_streaming_completion_empty_content(
+        self, openai_provider, simple_messages
+    ):
         """Test streaming completion with empty content chunks."""
         mock_chunks = [
-            MagicMock(choices=[MagicMock(delta=MagicMock(content=None), finish_reason=None)]),
-            MagicMock(choices=[MagicMock(delta=MagicMock(content="Hello"), finish_reason=None)]),
-            MagicMock(choices=[MagicMock(delta=MagicMock(content=None), finish_reason="stop")])
+            MagicMock(
+                choices=[MagicMock(delta=MagicMock(content=None), finish_reason=None)]
+            ),
+            MagicMock(
+                choices=[
+                    MagicMock(delta=MagicMock(content="Hello"), finish_reason=None)
+                ]
+            ),
+            MagicMock(
+                choices=[MagicMock(delta=MagicMock(content=None), finish_reason="stop")]
+            ),
         ]
-        
+
         async def mock_stream():
             for chunk in mock_chunks:
                 yield chunk
-        
+
         openai_provider.client.chat.completions.create.return_value = mock_stream()
-        
+
         results = []
-        async for chunk in openai_provider.generate_streaming_completion(simple_messages):
+        async for chunk in openai_provider.generate_streaming_completion(
+            simple_messages
+        ):
             results.append(chunk)
-        
+
         # Should only yield chunks with actual content
         assert len(results) == 1
         assert results[0]["content"] == "Hello"
-    
+
     @pytest.mark.asyncio
-    async def test_generate_streaming_completion_error(self, openai_provider, simple_messages):
+    async def test_generate_streaming_completion_error(
+        self, openai_provider, simple_messages
+    ):
         """Test streaming completion with error."""
         error_msg = "Streaming connection failed"
-        openai_provider.client.chat.completions.create.side_effect = Exception(error_msg)
-        
+        openai_provider.client.chat.completions.create.side_effect = Exception(
+            error_msg
+        )
+
         with pytest.raises(LLMException, match="OpenAI streaming error"):
-            async for _ in openai_provider.generate_streaming_completion(simple_messages):
+            async for _ in openai_provider.generate_streaming_completion(
+                simple_messages
+            ):
                 pass
+
 
 class TestAnthropicProvider:
     """Test Anthropic provider implementation."""
-    
+
     @pytest.fixture
     def anthropic_provider(self, anthropic_config):
         """Create Anthropic provider instance for testing."""
-        with patch('adaptive_graph_of_thoughts.services.llm.anthropic.AsyncAnthropic') as mock_anthropic:
+        with patch(
+            "adaptive_graph_of_thoughts.services.llm.anthropic.AsyncAnthropic"
+        ) as mock_anthropic:
             provider = AnthropicProvider(anthropic_config)
             provider.client = AsyncMock()
             return provider
-    
+
     def test_anthropic_provider_initialization(self, anthropic_config):
         """Test Anthropic provider initialization."""
-        with patch('adaptive_graph_of_thoughts.services.llm.anthropic.AsyncAnthropic') as mock_anthropic:
+        with patch(
+            "adaptive_graph_of_thoughts.services.llm.anthropic.AsyncAnthropic"
+        ) as mock_anthropic:
             provider = AnthropicProvider(anthropic_config)
-            
+
             assert provider.config == anthropic_config
             mock_anthropic.assert_called_once_with(
                 api_key=anthropic_config.api_key,
                 timeout=anthropic_config.timeout,
                 max_retries=anthropic_config.max_retries,
-                default_headers=anthropic_config.additional_headers
+                default_headers=anthropic_config.additional_headers,
             )
-    
+
     def test_convert_messages_with_system(self, anthropic_provider):
         """Test message conversion with system message."""
         messages = [
             {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi there!"},
-            {"role": "user", "content": "How are you?"}
+            {"role": "user", "content": "How are you?"},
         ]
-        
+
         system_msg, conv_msgs = anthropic_provider._convert_messages(messages)
-        
+
         assert system_msg == "You are a helpful assistant."
         assert len(conv_msgs) == 3
         assert conv_msgs[0] == {"role": "user", "content": "Hello"}
         assert conv_msgs[1] == {"role": "assistant", "content": "Hi there!"}
         assert conv_msgs[2] == {"role": "user", "content": "How are you?"}
-    
+
     def test_convert_messages_without_system(self, anthropic_provider):
         """Test message conversion without system message."""
         messages = [
             {"role": "user", "content": "Hello"},
-            {"role": "assistant", "content": "Hi!"}
+            {"role": "assistant", "content": "Hi!"},
         ]
-        
+
         system_msg, conv_msgs = anthropic_provider._convert_messages(messages)
-        
+
         assert system_msg == ""
         assert len(conv_msgs) == 2
         assert conv_msgs == messages
-    
+
     def test_convert_messages_multiple_systems(self, anthropic_provider):
         """Test message conversion with multiple system messages."""
         messages = [
             {"role": "system", "content": "First system message."},
             {"role": "system", "content": "Second system message."},
-            {"role": "user", "content": "Hello"}
+            {"role": "user", "content": "Hello"},
         ]
-        
+
         system_msg, conv_msgs = anthropic_provider._convert_messages(messages)
-        
+
         # Should use the last system message
         assert system_msg == "Second system message."
         assert len(conv_msgs) == 1
         assert conv_msgs[0] == {"role": "user", "content": "Hello"}
-    
+
     @pytest.mark.asyncio
-    async def test_generate_completion_success(self, anthropic_provider, sample_messages, mock_anthropic_response):
+    async def test_generate_completion_success(
+        self, anthropic_provider, sample_messages, mock_anthropic_response
+    ):
         """Test successful completion generation with Anthropic."""
         anthropic_provider.client.messages.create.return_value = mock_anthropic_response
-        
+
         result = await anthropic_provider.generate_completion(sample_messages)
-        
+
         assert result["content"] == "Hello! I'm Claude, nice to meet you."
         assert result["usage"]["total_tokens"] == 20  # 12 + 8
         assert result["usage"]["prompt_tokens"] == 12
         assert result["usage"]["completion_tokens"] == 8
         assert result["model"] == "claude-3-sonnet-20240229"
         assert result["finish_reason"] == "end_turn"
-    
+
     @pytest.mark.asyncio
-    async def test_generate_completion_with_system_message(self, anthropic_provider, mock_anthropic_response):
+    async def test_generate_completion_with_system_message(
+        self, anthropic_provider, mock_anthropic_response
+    ):
         """Test completion generation with system message."""
         messages = [
             {"role": "system", "content": "You are a coding assistant."},
-            {"role": "user", "content": "Write a Python function."}
+            {"role": "user", "content": "Write a Python function."},
         ]
-        
+
         anthropic_provider.client.messages.create.return_value = mock_anthropic_response
-        
+
         result = await anthropic_provider.generate_completion(messages)
-        
+
         assert result["content"] == "Hello! I'm Claude, nice to meet you."
-        
+
         # Verify the client was called with correct parameters
         call_args = anthropic_provider.client.messages.create.call_args
         assert call_args[1]["system"] == "You are a coding assistant."
         assert len(call_args[1]["messages"]) == 1
         assert call_args[1]["messages"][0]["content"] == "Write a Python function."
-    
+
     @pytest.mark.asyncio
-    async def test_generate_completion_without_system_message(self, anthropic_provider, mock_anthropic_response):
+    async def test_generate_completion_without_system_message(
+        self, anthropic_provider, mock_anthropic_response
+    ):
         """Test completion generation without system message."""
         messages = [{"role": "user", "content": "Hello"}]
-        
+
         anthropic_provider.client.messages.create.return_value = mock_anthropic_response
-        
+
         result = await anthropic_provider.generate_completion(messages)
-        
+
         assert result["content"] == "Hello! I'm Claude, nice to meet you."
-        
+
         # Verify system parameter is None when no system message
         call_args = anthropic_provider.client.messages.create.call_args
         assert call_args[1]["system"] is None
-    
+
     @pytest.mark.asyncio
-    async def test_generate_completion_token_limit_error(self, anthropic_provider, simple_messages):
+    async def test_generate_completion_token_limit_error(
+        self, anthropic_provider, simple_messages
+    ):
         """Test completion generation with token limit error."""
         error_msg = "Request exceeds maximum token limit"
         anthropic_provider.client.messages.create.side_effect = Exception(error_msg)
-        
+
         with pytest.raises(TokenLimitExceeded, match="Token limit exceeded"):
             await anthropic_provider.generate_completion(simple_messages)
-    
+
     @pytest.mark.asyncio
-    async def test_generate_completion_rate_limit_error(self, anthropic_provider, simple_messages):
+    async def test_generate_completion_rate_limit_error(
+        self, anthropic_provider, simple_messages
+    ):
         """Test completion generation with rate limit error."""
         error_msg = "API rate limit exceeded"
         anthropic_provider.client.messages.create.side_effect = Exception(error_msg)
-        
+
         with pytest.raises(RateLimitExceeded, match="Rate limit exceeded"):
             await anthropic_provider.generate_completion(simple_messages)
-    
+
     @pytest.mark.asyncio
-    async def test_generate_completion_generic_error(self, anthropic_provider, simple_messages):
+    async def test_generate_completion_generic_error(
+        self, anthropic_provider, simple_messages
+    ):
         """Test completion generation with generic error."""
         error_msg = "Authentication failed"
         anthropic_provider.client.messages.create.side_effect = Exception(error_msg)
-        
+
         with pytest.raises(LLMException, match="Anthropic API error"):
             await anthropic_provider.generate_completion(simple_messages)
-    
+
     @pytest.mark.asyncio
-    async def test_generate_streaming_completion_success(self, anthropic_provider, simple_messages):
+    async def test_generate_streaming_completion_success(
+        self, anthropic_provider, simple_messages
+    ):
         """Test successful streaming completion generation."""
         mock_chunks = [
             MagicMock(delta=MagicMock(text="Hello"), stop_reason=None),
             MagicMock(delta=MagicMock(text=" world"), stop_reason=None),
-            MagicMock(delta=MagicMock(text="!"), stop_reason="end_turn")
+            MagicMock(delta=MagicMock(text="!"), stop_reason="end_turn"),
         ]
-        
+
         async def mock_stream():
             for chunk in mock_chunks:
                 yield chunk
-        
+
         anthropic_provider.client.messages.create.return_value = mock_stream()
-        
+
         results = []
-        async for chunk in anthropic_provider.generate_streaming_completion(simple_messages):
+        async for chunk in anthropic_provider.generate_streaming_completion(
+            simple_messages
+        ):
             results.append(chunk)
-        
+
         assert len(results) == 3
         assert results[0]["content"] == "Hello"
         assert results[1]["content"] == " world"
         assert results[2]["content"] == "!"
         assert results[2]["finish_reason"] == "end_turn"
-    
+
     @pytest.mark.asyncio
-    async def test_generate_streaming_completion_no_delta(self, anthropic_provider, simple_messages):
+    async def test_generate_streaming_completion_no_delta(
+        self, anthropic_provider, simple_messages
+    ):
         """Test streaming completion with chunks missing delta."""
         mock_chunks = [
             MagicMock(spec=[]),  # Missing delta attribute
-            MagicMock(delta=MagicMock(text="Hello"))
+            MagicMock(delta=MagicMock(text="Hello")),
         ]
-        
+
         async def mock_stream():
             for chunk in mock_chunks:
                 yield chunk
-        
+
         anthropic_provider.client.messages.create.return_value = mock_stream()
-        
+
         results = []
-        async for chunk in anthropic_provider.generate_streaming_completion(simple_messages):
+        async for chunk in anthropic_provider.generate_streaming_completion(
+            simple_messages
+        ):
             results.append(chunk)
-        
+
         # Should only yield chunks with valid delta
         assert len(results) == 1
         assert results[0]["content"] == "Hello"
-    
+
     @pytest.mark.asyncio
-    async def test_generate_streaming_completion_error(self, anthropic_provider, simple_messages):
+    async def test_generate_streaming_completion_error(
+        self, anthropic_provider, simple_messages
+    ):
         """Test streaming completion with error."""
         error_msg = "Streaming failed"
         anthropic_provider.client.messages.create.side_effect = Exception(error_msg)
-        
+
         with pytest.raises(LLMException, match="Anthropic streaming error"):
-            async for _ in anthropic_provider.generate_streaming_completion(simple_messages):
+            async for _ in anthropic_provider.generate_streaming_completion(
+                simple_messages
+            ):
                 pass
+
 
 class TestLLMService:
     """Test main LLMService functionality."""
-    
+
     def test_llm_service_initialization_openai(self, base_config):
         """Test LLMService initialization with OpenAI provider."""
-        with patch('adaptive_graph_of_thoughts.services.llm.OpenAIProvider') as mock_provider:
+        with patch(
+            "adaptive_graph_of_thoughts.services.llm.OpenAIProvider"
+        ) as mock_provider:
             service = LLMService(base_config)
-            
+
             assert service.config == base_config
             mock_provider.assert_called_once_with(base_config)
             assert service._usage_stats["total_requests"] == 0
@@ -598,153 +698,169 @@ class TestLLMService:
             assert service._usage_stats["errors"] == []
             assert service._cache == {}
             assert service._cache_ttl == 3600
-    
+
     def test_llm_service_initialization_anthropic(self, anthropic_config):
         """Test LLMService initialization with Anthropic provider."""
-        with patch('adaptive_graph_of_thoughts.services.llm.AnthropicProvider') as mock_provider:
+        with patch(
+            "adaptive_graph_of_thoughts.services.llm.AnthropicProvider"
+        ) as mock_provider:
             service = LLMService(anthropic_config)
-            
+
             assert service.config == anthropic_config
             mock_provider.assert_called_once_with(anthropic_config)
-    
+
     def test_llm_service_unsupported_provider(self):
         """Test LLMService initialization with unsupported provider."""
         config = LLMConfig(
-            provider="unsupported",
-            model="test-model",
-            api_key="test-key"
+            provider="unsupported", model="test-model", api_key="test-key"
         )
-        
+
         with pytest.raises(ValueError, match="Unsupported provider: unsupported"):
             LLMService(config)
-    
+
     def test_validate_messages_empty(self, base_config):
         """Test message validation with empty message list."""
-        with patch('adaptive_graph_of_thoughts.services.llm.OpenAIProvider'):
+        with patch("adaptive_graph_of_thoughts.services.llm.OpenAIProvider"):
             service = LLMService(base_config)
-            
+
             with pytest.raises(ValueError, match="Messages cannot be empty"):
                 service._validate_messages([])
-    
+
     def test_validate_messages_invalid_format(self, base_config):
         """Test message validation with invalid message format."""
-        with patch('adaptive_graph_of_thoughts.services.llm.OpenAIProvider'):
+        with patch("adaptive_graph_of_thoughts.services.llm.OpenAIProvider"):
             service = LLMService(base_config)
-            
+
             # Test non-dict message
             with pytest.raises(ValueError, match="Each message must be a dictionary"):
                 service._validate_messages(["invalid"])
-            
+
             # Test missing role
-            with pytest.raises(ValueError, match="Each message must have 'role' and 'content' keys"):
+            with pytest.raises(
+                ValueError, match="Each message must have 'role' and 'content' keys"
+            ):
                 service._validate_messages([{"content": "test"}])
-            
+
             # Test missing content
-            with pytest.raises(ValueError, match="Each message must have 'role' and 'content' keys"):
+            with pytest.raises(
+                ValueError, match="Each message must have 'role' and 'content' keys"
+            ):
                 service._validate_messages([{"role": "user"}])
-            
+
             # Test invalid role
-            with pytest.raises(ValueError, match="Message role must be 'system', 'user', or 'assistant'"):
+            with pytest.raises(
+                ValueError,
+                match="Message role must be 'system', 'user', or 'assistant'",
+            ):
                 service._validate_messages([{"role": "invalid", "content": "test"}])
-    
+
     def test_validate_messages_valid(self, base_config, sample_messages):
         """Test message validation with valid messages."""
-        with patch('adaptive_graph_of_thoughts.services.llm.OpenAIProvider'):
+        with patch("adaptive_graph_of_thoughts.services.llm.OpenAIProvider"):
             service = LLMService(base_config)
-            
+
             # Should not raise any exception
             service._validate_messages(sample_messages)
-    
+
     def test_generate_cache_key(self, base_config):
         """Test cache key generation."""
-        with patch('adaptive_graph_of_thoughts.services.llm.OpenAIProvider'):
+        with patch("adaptive_graph_of_thoughts.services.llm.OpenAIProvider"):
             service = LLMService(base_config)
-            
+
             messages = [{"role": "user", "content": "test"}]
             key1 = service._generate_cache_key(messages)
             key2 = service._generate_cache_key(messages)
-            
+
             # Same messages should generate same key
             assert key1 == key2
             assert isinstance(key1, str)
-            
+
             # Different messages should generate different keys
             different_messages = [{"role": "user", "content": "different"}]
             key3 = service._generate_cache_key(different_messages)
             assert key1 != key3
-    
+
     def test_generate_cache_key_with_kwargs(self, base_config):
         """Test cache key generation with kwargs."""
-        with patch('adaptive_graph_of_thoughts.services.llm.OpenAIProvider'):
+        with patch("adaptive_graph_of_thoughts.services.llm.OpenAIProvider"):
             service = LLMService(base_config)
-            
+
             messages = [{"role": "user", "content": "test"}]
             key1 = service._generate_cache_key(messages)
             key2 = service._generate_cache_key(messages, top_p=0.9)
-            
+
             # Different kwargs should generate different keys
             assert key1 != key2
-    
+
     def test_cache_operations(self, base_config):
         """Test cache operations."""
-        with patch('adaptive_graph_of_thoughts.services.llm.OpenAIProvider'):
+        with patch("adaptive_graph_of_thoughts.services.llm.OpenAIProvider"):
             service = LLMService(base_config)
-            
+
             cache_key = "test_key"
             response = {"content": "test response"}
-            
+
             # Test caching response
             service._cache_response(cache_key, response)
             assert cache_key in service._cache
             assert service._cache[cache_key]["response"] == response
             assert "timestamp" in service._cache[cache_key]
-            
+
             # Test getting cached response
             cached = service._get_cached_response(cache_key)
             assert cached == response
-    
+
     def test_cache_expiration(self, base_config):
         """Test cache expiration."""
-        with patch('adaptive_graph_of_thoughts.services.llm.OpenAIProvider'):
+        with patch("adaptive_graph_of_thoughts.services.llm.OpenAIProvider"):
             service = LLMService(base_config)
             service.set_cache_ttl(1)  # 1 second TTL
-            
+
             cache_key = "test_key"
             response = {"content": "test response"}
-            
+
             # Cache response
             service._cache_response(cache_key, response)
-            
+
             # Should be available immediately
             cached = service._get_cached_response(cache_key)
             assert cached == response
-            
+
             # Mock time passage
-            with patch('adaptive_graph_of_thoughts.services.llm.time.time', return_value=time.time() + 2):
+            with patch(
+                "adaptive_graph_of_thoughts.services.llm.time.time",
+                return_value=time.time() + 2,
+            ):
                 cached = service._get_cached_response(cache_key)
                 assert cached is None  # Should be expired
                 assert cache_key not in service._cache  # Should be removed
-    
+
     def test_clear_cache(self, base_config):
         """Test cache clearing."""
-        with patch('adaptive_graph_of_thoughts.services.llm.OpenAIProvider'):
+        with patch("adaptive_graph_of_thoughts.services.llm.OpenAIProvider"):
             service = LLMService(base_config)
-            
+
             # Add some cache entries
-            service._cache["key1"] = {"response": {"content": "test1"}, "timestamp": time.time()}
-            service._cache["key2"] = {"response": {"content": "test2"}, "timestamp": time.time()}
-            
+            service._cache["key1"] = {
+                "response": {"content": "test1"},
+                "timestamp": time.time(),
+            }
+            service._cache["key2"] = {
+                "response": {"content": "test2"},
+                "timestamp": time.time(),
+            }
+
             assert len(service._cache) == 2
-            
+
             service.clear_cache()
             assert len(service._cache) == 0
-    
+
     def test_set_cache_ttl(self, base_config):
         """Test setting cache TTL."""
-        with patch('adaptive_graph_of_thoughts.services.llm.OpenAIProvider'):
+        with patch("adaptive_graph_of_thoughts.services.llm.OpenAIProvider"):
             service = LLMService(base_config)
-            
+
             assert service._cache_ttl == 3600  # Default
-            
+
             service.set_cache_ttl(7200)
             assert service._cache_ttl == 7200

--- a/tests/unit/test_app_setup.py
+++ b/tests/unit/test_app_setup.py
@@ -3,6 +3,7 @@
 This module tests all functionality related to application setup, configuration,
 initialization, and teardown processes.
 """
+
 import pytest
 from unittest.mock import Mock, patch, MagicMock, call
 import os
@@ -17,6 +18,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent / "git" / "src"))
 
 from adaptive_graph_of_thoughts.app_setup import *
 
+
 @pytest.fixture
 def mock_config() -> Dict[str, Any]:
     """Provide a mock configuration object for testing."""
@@ -26,8 +28,9 @@ def mock_config() -> Dict[str, Any]:
         "log_level": "INFO",
         "api_key": "test_api_key",
         "timeout": 30,
-        "max_retries": 3
+        "max_retries": 3,
     }
+
 
 @pytest.fixture
 def invalid_config() -> Dict[str, Any]:
@@ -37,8 +40,9 @@ def invalid_config() -> Dict[str, Any]:
         "debug": "not_a_boolean",
         "log_level": "INVALID_LEVEL",
         "timeout": -1,
-        "max_retries": "not_a_number"
+        "max_retries": "not_a_number",
     }
+
 
 @pytest.fixture
 def temp_directory() -> str:
@@ -47,11 +51,13 @@ def temp_directory() -> str:
     yield temp_dir
     shutil.rmtree(temp_dir)
 
+
 @pytest.fixture
 def mock_logger():
     """Provide a mock logger for testing logging functionality."""
     with patch("adaptive_graph_of_thoughts.app_setup.logger") as mock_log:
         yield mock_log
+
 
 class TestAppSetup:
     """Test suite for core application setup functionality."""
@@ -60,7 +66,9 @@ class TestAppSetup:
         initialize_app(mock_config)
         mock_logger.info.assert_called()
 
-    def test_initialize_app_with_invalid_config_raises_error(self, invalid_config, mock_logger):
+    def test_initialize_app_with_invalid_config_raises_error(
+        self, invalid_config, mock_logger
+    ):
         with pytest.raises(ValueError, match="Invalid configuration"):
             initialize_app(invalid_config)
 
@@ -68,25 +76,33 @@ class TestAppSetup:
         initialize_app({})
         mock_logger.info.assert_called()
 
-    @pytest.mark.parametrize("config_key,invalid_value,expected_error", [
-        ("database_url", None, "Database URL cannot be None"),
-        ("database_url", "", "Database URL cannot be empty"),
-        ("timeout", -1, "Timeout must be positive"),
-        ("timeout", "invalid", "Timeout must be a number"),
-        ("max_retries", -1, "Max retries must be non-negative"),
-        ("log_level", "INVALID", "Invalid log level"),
-    ])
-    def test_validate_config_with_invalid_values(self, mock_config, config_key, invalid_value, expected_error):
+    @pytest.mark.parametrize(
+        "config_key,invalid_value,expected_error",
+        [
+            ("database_url", None, "Database URL cannot be None"),
+            ("database_url", "", "Database URL cannot be empty"),
+            ("timeout", -1, "Timeout must be positive"),
+            ("timeout", "invalid", "Timeout must be a number"),
+            ("max_retries", -1, "Max retries must be non-negative"),
+            ("log_level", "INVALID", "Invalid log level"),
+        ],
+    )
+    def test_validate_config_with_invalid_values(
+        self, mock_config, config_key, invalid_value, expected_error
+    ):
         config = mock_config.copy()
         config[config_key] = invalid_value
         with pytest.raises(ValueError, match=expected_error):
             validate_config(config)
 
+
 class TestDatabaseSetup:
     """Test suite for database setup and connection management."""
 
     @patch("adaptive_graph_of_thoughts.app_setup.create_engine")
-    def test_setup_database_with_valid_url_creates_engine(self, mock_create_engine, mock_config):
+    def test_setup_database_with_valid_url_creates_engine(
+        self, mock_create_engine, mock_config
+    ):
         mock_engine = Mock()
         mock_create_engine.return_value = mock_engine
         engine = setup_database(mock_config["database_url"], mock_config["max_retries"])
@@ -100,7 +116,11 @@ class TestDatabaseSetup:
 
     def test_database_connection_retry_logic(self, mock_config):
         with patch("adaptive_graph_of_thoughts.app_setup.create_engine") as mock_create:
-            mock_create.side_effect = [Exception("Connection failed"), Exception("Connection failed"), Mock()]
+            mock_create.side_effect = [
+                Exception("Connection failed"),
+                Exception("Connection failed"),
+                Mock(),
+            ]
             engine = setup_database(mock_config["database_url"], 3)
             assert engine is not None
 
@@ -109,6 +129,7 @@ class TestDatabaseSetup:
             mock_create.side_effect = Exception("Connection failed")
             with pytest.raises(Exception, match="Max retries exceeded"):
                 setup_database(mock_config["database_url"], mock_config["max_retries"])
+
 
 class TestLoggingSetup:
     """Test suite for logging configuration and setup."""
@@ -120,7 +141,10 @@ class TestLoggingSetup:
         setup_logging(mock_config)
         mock_get_logger.assert_called_with("app")
 
-    @pytest.mark.parametrize("log_level", ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"])
+    @pytest.mark.parametrize(
+        "log_level",
+        ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+    )
     def test_setup_logging_with_different_levels(self, log_level, mock_config):
         config = mock_config.copy()
         config["log_level"] = log_level
@@ -135,12 +159,15 @@ class TestLoggingSetup:
         setup_logging(config)
         assert os.path.exists(log_file)
 
-    def test_setup_logging_with_invalid_log_file_path_falls_back_to_console(self, mock_config):
+    def test_setup_logging_with_invalid_log_file_path_falls_back_to_console(
+        self, mock_config
+    ):
         config = mock_config.copy()
         config["log_file"] = "/invalid/path/test.log"
         with patch("adaptive_graph_of_thoughts.app_setup.logging") as mock_logging:
             setup_logging(config)
             mock_logging.getLogger.return_value.addHandler.assert_called()
+
 
 class TestConfigurationManagement:
     """Test suite for configuration management and environment handling."""
@@ -150,7 +177,7 @@ class TestConfigurationManagement:
             "APP_DATABASE_URL": "postgresql://test:test@localhost/testdb",
             "APP_DEBUG": "true",
             "APP_LOG_LEVEL": "DEBUG",
-            "APP_TIMEOUT": "60"
+            "APP_TIMEOUT": "60",
         }
         with patch.dict(os.environ, env_vars):
             config = load_config()
@@ -161,9 +188,14 @@ class TestConfigurationManagement:
 
     def test_load_config_from_file(self, temp_directory):
         config_file = os.path.join(temp_directory, "config.json")
-        data = {"database_url": "sqlite:///file.db", "debug": False, "log_level": "WARNING"}
+        data = {
+            "database_url": "sqlite:///file.db",
+            "debug": False,
+            "log_level": "WARNING",
+        }
         with open(config_file, "w") as f:
             import json
+
             json.dump(data, f)
         config = load_config(config_file)
         assert config["database_url"] == data["database_url"]
@@ -174,6 +206,7 @@ class TestConfigurationManagement:
         file_data = {"debug": False, "timeout": 30}
         with open(config_file, "w") as f:
             import json
+
             json.dump(file_data, f)
         env_vars = {"APP_DEBUG": "true", "APP_TIMEOUT": "60"}
         with patch.dict(os.environ, env_vars):
@@ -181,12 +214,18 @@ class TestConfigurationManagement:
             assert config["debug"] is True
             assert config["timeout"] == 60
 
-    @pytest.mark.parametrize("missing_key", ["database_url", "log_level", "timeout"])
-    def test_config_with_missing_required_keys_uses_defaults(self, missing_key, mock_config):
+    @pytest.mark.parametrize(
+        "missing_key",
+        ["database_url", "log_level", "timeout"],
+    )
+    def test_config_with_missing_required_keys_uses_defaults(
+        self, missing_key, mock_config
+    ):
         config = mock_config.copy()
         del config[missing_key]
         result = load_config(config)
         assert missing_key in result
+
 
 class TestApplicationLifecycle:
     """Test suite for application lifecycle management."""
@@ -196,7 +235,7 @@ class TestApplicationLifecycle:
             "adaptive_graph_of_thoughts.app_setup",
             setup_database=Mock(),
             setup_logging=Mock(),
-            setup_monitoring=Mock()
+            setup_monitoring=Mock(),
         ) as mocks:
             initialize_app(mock_config)
             mocks["setup_database"].assert_called_once()
@@ -208,7 +247,7 @@ class TestApplicationLifecycle:
             "adaptive_graph_of_thoughts.app_setup",
             cleanup_database=Mock(),
             cleanup_logging=Mock(),
-            cleanup_monitoring=Mock()
+            cleanup_monitoring=Mock(),
         ) as mocks:
             shutdown_app()
             mocks["cleanup_database"].assert_called_once()
@@ -231,37 +270,46 @@ class TestApplicationLifecycle:
         shutdown_app()
         shutdown_app()
 
+
 class TestConcurrencyAndPerformance:
     """Test suite for concurrency and performance aspects."""
 
     def test_concurrent_initialization_thread_safety(self, mock_config):
         import threading
+
         results, errors = [], []
+
         def target():
             try:
                 initialize_app(mock_config)
                 results.append(True)
             except Exception as e:
                 errors.append(e)
+
         threads = [threading.Thread(target=target) for _ in range(10)]
-        for t in threads: t.start()
-        for t in threads: t.join()
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
         assert not errors
         assert len(results) == 10
 
     def test_initialization_performance_within_limits(self, mock_config):
         import time
+
         start = time.time()
         initialize_app(mock_config)
         assert time.time() - start < 5.0
 
     def test_memory_usage_during_initialization(self, mock_config):
         import psutil, os
+
         proc = psutil.Process(os.getpid())
         before = proc.memory_info().rss
         initialize_app(mock_config)
         after = proc.memory_info().rss
         assert after - before < 100 * 1024 * 1024
+
 
 class TestComponentIntegration:
     """Test suite for integration between app_setup components."""
@@ -272,7 +320,9 @@ class TestComponentIntegration:
             initialize_app(mock_config)
             mock_logger.info.assert_any_call("Database engine created")
 
-    def test_config_validation_and_error_logging_integration(self, invalid_config, mock_logger):
+    def test_config_validation_and_error_logging_integration(
+        self, invalid_config, mock_logger
+    ):
         with pytest.raises(ValueError):
             initialize_app(invalid_config)
         mock_logger.error.assert_called()
@@ -281,7 +331,7 @@ class TestComponentIntegration:
         with patch.multiple(
             "adaptive_graph_of_thoughts.app_setup",
             setup_database=Mock(),
-            setup_monitoring=Mock()
+            setup_monitoring=Mock(),
         ) as mocks:
             initialize_app(mock_config)
             mocks["setup_monitoring"].assert_called()
@@ -291,6 +341,7 @@ class TestComponentIntegration:
         new_config["debug"] = False
         update_config(new_config)
         assert get_current_config()["debug"] is False
+
 
 class TestEdgeCasesAndErrorHandling:
     """Test suite for edge cases and comprehensive error handling."""
@@ -332,19 +383,21 @@ class TestEdgeCasesAndErrorHandling:
         corrupt_state()
         initialize_app(mock_config)
 
+
 # Additional utility functions for test helpers
 def create_test_database_url(temp_directory: str) -> str:
     """Create a test database URL pointing to a temporary database."""
     db_path = os.path.join(temp_directory, "test.db")
     return f"sqlite:///{db_path}"
 
+
 def assert_cleanup_completed(mock_logger):
     """Assert that cleanup operations completed successfully."""
     cleanup_calls = [
-        c for c in mock_logger.info.call_args_list
-        if "cleanup" in str(c).lower()
+        c for c in mock_logger.info.call_args_list if "cleanup" in str(c).lower()
     ]
     assert cleanup_calls
+
 
 def assert_initialization_order(mock_calls, expected_order):
     """Assert that initialization steps occurred in the expected order."""

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -41,8 +41,8 @@ def clear_llm_logs():
     LLM_QUERY_LOGS.clear()
 
 class TestLLMClaudeProvider:
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.anthropic')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.anthropic")
     def test_ask_llm_claude_success(self, mock_anthropic, mock_env_settings, mock_claude_response):
         """Test successful LLM call with Claude provider"""
         mock_env_settings.llm_provider = "claude"
@@ -61,8 +61,8 @@ class TestLLMClaudeProvider:
             messages=[{"role": "user", "content": "Test prompt"}]
         )
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.anthropic')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.anthropic")
     @patch.dict(os.environ, {'CLAUDE_MODEL': 'claude-3-opus-20240229'})
     def test_ask_llm_claude_custom_model(self, mock_anthropic, mock_env_settings, mock_claude_response):
         """Test Claude provider with custom model from environment variable"""
@@ -81,8 +81,8 @@ class TestLLMClaudeProvider:
             messages=[{"role": "user", "content": "Test prompt"}]
         )
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.anthropic')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.anthropic")
     def test_ask_llm_claude_api_error(self, mock_anthropic, mock_env_settings):
         """Test Claude provider with API error"""
         mock_env_settings.llm_provider = "claude"
@@ -96,8 +96,8 @@ class TestLLMClaudeProvider:
 
         assert result == "LLM error: API Error"
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.anthropic')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.anthropic")
     def test_ask_llm_claude_case_insensitive(self, mock_anthropic, mock_env_settings, mock_claude_response):
         """Test Claude provider with case insensitive provider name"""
         mock_env_settings.llm_provider = "CLAUDE"
@@ -112,8 +112,8 @@ class TestLLMClaudeProvider:
         assert result == "Claude response text"
 
 class TestLLMOpenAIProvider:
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_ask_llm_openai_success(self, mock_openai, mock_env_settings, mock_openai_response):
         """Test successful LLM call with OpenAI provider"""
         mock_env_settings.llm_provider = "openai"
@@ -132,8 +132,8 @@ class TestLLMOpenAIProvider:
             messages=[{"role": "user", "content": "Test prompt"}]
         )
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     @patch.dict(os.environ, {'OPENAI_MODEL': 'gpt-4'})
     def test_ask_llm_openai_custom_model(self, mock_openai, mock_env_settings, mock_openai_response):
         """Test OpenAI provider with custom model from environment variable"""
@@ -152,8 +152,8 @@ class TestLLMOpenAIProvider:
             messages=[{"role": "user", "content": "Test prompt"}]
         )
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_ask_llm_openai_api_error(self, mock_openai, mock_env_settings):
         """Test OpenAI provider with API error"""
         mock_env_settings.llm_provider = "openai"
@@ -167,8 +167,8 @@ class TestLLMOpenAIProvider:
 
         assert result == "LLM error: API Error"
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_ask_llm_openai_default_provider(self, mock_openai, mock_env_settings, mock_openai_response):
         """Test that non-Claude provider defaults to OpenAI"""
         mock_env_settings.llm_provider = "unknown_provider"
@@ -182,8 +182,8 @@ class TestLLMOpenAIProvider:
 
         assert result == "OpenAI response text"
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_ask_llm_openai_response_stripping(self, mock_openai, mock_env_settings):
         """Test that OpenAI response content is properly stripped of whitespace"""
         mock_env_settings.llm_provider = "openai"
@@ -201,8 +201,8 @@ class TestLLMOpenAIProvider:
         assert result == "Response with whitespace"
 
 class TestLLMQueryLogging:
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_llm_query_logging_single_call(self, mock_openai, mock_env_settings, mock_openai_response):
         """Test that LLM queries are logged correctly"""
         mock_env_settings.llm_provider = "openai"
@@ -218,8 +218,8 @@ class TestLLMQueryLogging:
         assert LLM_QUERY_LOGS[0]["prompt"] == "Test prompt"
         assert LLM_QUERY_LOGS[0]["response"] == "OpenAI response text"
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_llm_query_logging_multiple_calls(self, mock_openai, mock_env_settings):
         """Test multiple LLM query logging"""
         mock_env_settings.llm_provider = "openai"
@@ -241,8 +241,8 @@ class TestLLMQueryLogging:
             assert LLM_QUERY_LOGS[i]["prompt"] == f"Prompt {i}"
             assert LLM_QUERY_LOGS[i]["response"] == f"Response {i}"
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_llm_query_logging_rotation(self, mock_openai, mock_env_settings):
         """Test that LLM query logs are rotated after 5 entries"""
         mock_env_settings.llm_provider = "openai"
@@ -266,8 +266,8 @@ class TestLLMQueryLogging:
             assert LLM_QUERY_LOGS[i]["prompt"] == f"Prompt {expected_index}"
             assert LLM_QUERY_LOGS[i]["response"] == f"Response {expected_index}"
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_llm_query_logging_error_not_logged(self, mock_openai, mock_env_settings):
         """Test that failed LLM queries are not logged"""
         mock_env_settings.llm_provider = "openai"
@@ -284,8 +284,8 @@ class TestLLMQueryLogging:
         assert result == "LLM error: API Error"
 
 class TestLLMEdgeCases:
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_ask_llm_empty_prompt(self, mock_openai, mock_env_settings, mock_openai_response):
         """Test LLM call with empty prompt"""
         mock_env_settings.llm_provider = "openai"
@@ -303,8 +303,8 @@ class TestLLMEdgeCases:
             messages=[{"role": "user", "content": ""}]
         )
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_ask_llm_very_long_prompt(self, mock_openai, mock_env_settings, mock_openai_response):
         """Test LLM call with very long prompt"""
         mock_env_settings.llm_provider = "openai"
@@ -323,8 +323,8 @@ class TestLLMEdgeCases:
             messages=[{"role": "user", "content": long_prompt}]
         )
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_ask_llm_special_characters(self, mock_openai, mock_env_settings, mock_openai_response):
         """Test LLM call with special characters in prompt"""
         mock_env_settings.llm_provider = "openai"
@@ -343,8 +343,8 @@ class TestLLMEdgeCases:
             messages=[{"role": "user", "content": special_prompt}]
         )
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_ask_llm_unicode_prompt(self, mock_openai, mock_env_settings, mock_openai_response):
         """Test LLM call with unicode characters in prompt"""
         mock_env_settings.llm_provider = "openai"
@@ -363,8 +363,8 @@ class TestLLMEdgeCases:
             messages=[{"role": "user", "content": unicode_prompt}]
         )
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.anthropic')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.anthropic")
     def test_ask_llm_claude_malformed_response(self, mock_anthropic, mock_env_settings):
         """Test Claude provider with malformed response"""
         mock_env_settings.llm_provider = "claude"
@@ -381,8 +381,8 @@ class TestLLMEdgeCases:
 
         assert "LLM error:" in result
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_ask_llm_openai_none_response(self, mock_openai, mock_env_settings):
         """Test OpenAI provider with None response content"""
         mock_env_settings.llm_provider = "openai"
@@ -400,20 +400,23 @@ class TestLLMEdgeCases:
         assert "LLM error:" in result
 
 class TestLLMParameterized:
-    @pytest.mark.parametrize("provider,expected_calls", [
-        ("claude", "anthropic"),
-        ("CLAUDE", "anthropic"),
-        ("Claude", "anthropic"),
-        ("openai", "openai"),
-        ("OPENAI", "openai"),
-        ("OpenAI", "openai"),
-        ("gpt", "openai"),
-        ("unknown", "openai"),
-        ("", "openai"),
-    ])
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.anthropic')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @pytest.mark.parametrize(
+        "provider,expected_calls",
+        [
+            ("claude", "anthropic"),
+            ("CLAUDE", "anthropic"),
+            ("Claude", "anthropic"),
+            ("openai", "openai"),
+            ("OPENAI", "openai"),
+            ("OpenAI", "openai"),
+            ("gpt", "openai"),
+            ("unknown", "openai"),
+            ("", "openai"),
+        ],
+    )
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.anthropic")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_provider_routing(self, mock_openai, mock_anthropic, mock_env_settings, provider, expected_calls):
         """Test that different provider names route to correct implementations"""
         mock_env_settings.llm_provider = provider
@@ -442,18 +445,21 @@ class TestLLMParameterized:
             assert "OpenAI response" in result
             mock_openai.OpenAI.assert_called_once()
 
-    @pytest.mark.parametrize("prompt", [
-        "Simple prompt",
-        "",
-        "A" * 1000,
-        "Unicode: 世界 🌍",
-        "Special chars: @#$%^&*()",
-        "Multi\nline\nprompt",
-        "Tab\tcharacters",
-        "Quotes 'single' \"double\"",
-    ])
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @pytest.mark.parametrize(
+        "prompt",
+        [
+            "Simple prompt",
+            "",
+            "A" * 1000,
+            "Unicode: 世界 🌍",
+            "Special chars: @#$%^&*()",
+            "Multi\nline\nprompt",
+            "Tab\tcharacters",
+            "Quotes 'single' \"double\"",
+        ],
+    )
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_various_prompt_types(self, mock_openai, mock_env_settings, prompt, mock_openai_response):
         """Test LLM with various prompt types and characters"""
         mock_env_settings.llm_provider = "openai"
@@ -472,8 +478,8 @@ class TestLLMParameterized:
         )
 
 class TestLLMStressAndPerformance:
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_multiple_sequential_calls(self, mock_openai, mock_env_settings):
         """Test multiple sequential LLM calls"""
         mock_env_settings.llm_provider = "openai"
@@ -500,15 +506,18 @@ class TestLLMStressAndPerformance:
             expected_index = i + 5
             assert LLM_QUERY_LOGS[i]["prompt"] == f"Prompt {expected_index}"
 
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.logger')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.logger")
     def test_error_logging(self, mock_logger, mock_env_settings):
         """Test that errors are properly logged"""
         mock_env_settings.llm_provider = "openai"
         mock_env_settings.openai_api_key = "test_key"
 
         # Mock import failure
-        with patch('adaptive_graph_of_thoughts.services.llm.openai', side_effect=ImportError("Module not found")):
+        with patch(
+            "adaptive_graph_of_thoughts.services.llm.openai",
+            side_effect=ImportError("Module not found"),
+        ):
             result = ask_llm("Test prompt")
 
             assert result == "LLM error: Module not found"
@@ -519,8 +528,12 @@ class TestLLMIntegration:
         """Test that LLM_QUERY_LOGS is properly managed as global state"""
         initial_length = len(LLM_QUERY_LOGS)
 
-        with patch('adaptive_graph_of_thoughts.services.llm.env_settings') as mock_env_settings:
-            with patch('adaptive_graph_of_thoughts.services.llm.openai') as mock_openai:
+        with patch(
+            "adaptive_graph_of_thoughts.services.llm.env_settings"
+        ) as mock_env_settings:
+            with patch(
+                "adaptive_graph_of_thoughts.services.llm.openai"
+            ) as mock_openai:
                 mock_env_settings.llm_provider = "openai"
                 mock_env_settings.openai_api_key = "test_key"
 
@@ -535,8 +548,8 @@ class TestLLMIntegration:
                 assert len(LLM_QUERY_LOGS) == initial_length + 1
 
     @patch.dict(os.environ, {}, clear=True)
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_environment_variable_defaults(self, mock_openai, mock_env_settings, mock_openai_response):
         """Test default model values when environment variables are not set"""
         mock_env_settings.llm_provider = "openai"
@@ -554,8 +567,8 @@ class TestLLMIntegration:
         )
 
     @patch.dict(os.environ, {'CLAUDE_MODEL': '', 'OPENAI_MODEL': ''})
-    @patch('adaptive_graph_of_thoughts.services.llm.env_settings')
-    @patch('adaptive_graph_of_thoughts.services.llm.openai')
+    @patch("adaptive_graph_of_thoughts.services.llm.env_settings")
+    @patch("adaptive_graph_of_thoughts.services.llm.openai")
     def test_empty_environment_variables(self, mock_openai, mock_env_settings, mock_openai_response):
         """Test behavior with empty environment variables"""
         mock_env_settings.llm_provider = "openai"

--- a/tests/unit/test_neo4j_utils.py
+++ b/tests/unit/test_neo4j_utils.py
@@ -68,7 +68,7 @@ def sample_relationship_data():
 @pytest.fixture
 def neo4j_connection():
     """Fixture for Neo4jConnection instance with mocked driver."""
-    with patch('adaptive_graph_of_thoughts.infrastructure.neo4j_utils.GraphDatabase.driver') as mock_driver_creator:
+    with patch("adaptive_graph_of_thoughts.infrastructure.neo4j_utils.GraphDatabase.driver") as mock_driver_creator:
         mock_driver = Mock(spec=Driver)
         mock_session = Mock(spec=Session)
         mock_session.__enter__ = Mock(return_value=mock_session)

--- a/tests/unit/test_vscode_utils.py
+++ b/tests/unit/test_vscode_utils.py
@@ -15,7 +15,7 @@ def test_vscode_parse_ndjson_integration():
     assert "OK" in result.stdout
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_vscode_parse_ndjson_success_mock(mock_run):
     """Test successful execution of vscode test utils with mocked subprocess."""
     # Mock successful execution
@@ -29,14 +29,16 @@ def test_vscode_parse_ndjson_success_mock(mock_run):
     result = subprocess.run(["node", str(script)], capture_output=True, text=True)
 
     # Verify subprocess was called correctly
-    mock_run.assert_called_once_with(["node", str(script)], capture_output=True, text=True)
+    mock_run.assert_called_once_with(
+        ["node", str(script)], capture_output=True, text=True
+    )
 
     # Verify results
     assert result.returncode == 0
     assert "OK" in result.stdout
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_vscode_parse_ndjson_failure_returncode(mock_run):
     """Test handling of non-zero return code from JavaScript test."""
     mock_result = Mock()
@@ -52,7 +54,7 @@ def test_vscode_parse_ndjson_failure_returncode(mock_run):
     assert "OK" not in result.stdout
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_vscode_parse_ndjson_missing_ok_in_output(mock_run):
     """Test when subprocess succeeds but doesn't contain expected 'OK' output."""
     mock_result = Mock()
@@ -68,7 +70,7 @@ def test_vscode_parse_ndjson_missing_ok_in_output(mock_run):
     assert "OK" not in result.stdout
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_vscode_parse_ndjson_subprocess_exception(mock_run):
     """Test handling of subprocess execution exceptions."""
     mock_run.side_effect = FileNotFoundError("node command not found")
@@ -79,7 +81,7 @@ def test_vscode_parse_ndjson_subprocess_exception(mock_run):
         subprocess.run(["node", str(script)], capture_output=True, text=True)
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_vscode_parse_ndjson_timeout_exception(mock_run):
     """Test handling of subprocess timeout."""
     mock_run.side_effect = subprocess.TimeoutExpired("node", 30)
@@ -87,7 +89,9 @@ def test_vscode_parse_ndjson_timeout_exception(mock_run):
     script = Path("integrations/vscode-agot/test_utils.js")
 
     with pytest.raises(subprocess.TimeoutExpired):
-        subprocess.run(["node", str(script)], capture_output=True, text=True, timeout=30)
+        subprocess.run(
+            ["node", str(script)], capture_output=True, text=True, timeout=30
+        )
 
 
 def test_vscode_test_script_path_exists():
@@ -113,7 +117,7 @@ def test_vscode_test_script_path_handling():
     assert resolved_path.is_absolute()
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_vscode_parse_ndjson_with_stderr_output(mock_run):
     """Test handling when subprocess has stderr output but still succeeds."""
     mock_result = Mock()
@@ -130,7 +134,7 @@ def test_vscode_parse_ndjson_with_stderr_output(mock_run):
     assert "Warning" in result.stderr
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_vscode_parse_ndjson_empty_output(mock_run):
     """Test handling of empty stdout from subprocess."""
     mock_result = Mock()
@@ -146,7 +150,7 @@ def test_vscode_parse_ndjson_empty_output(mock_run):
     assert "OK" not in result.stdout
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_vscode_parse_ndjson_case_sensitive_ok_check(mock_run):
     """Test that OK check is case sensitive."""
     mock_result = Mock()
@@ -163,7 +167,7 @@ def test_vscode_parse_ndjson_case_sensitive_ok_check(mock_run):
     assert "ok" in result.stdout
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_vscode_parse_ndjson_multiple_ok_in_output(mock_run):
     """Test when output contains multiple instances of OK."""
     mock_result = Mock()
@@ -183,7 +187,7 @@ def test_vscode_parse_ndjson_multiple_ok_in_output(mock_run):
 class TestVSCodeTestUtilsEdgeCases:
     """Test class for edge cases and boundary conditions."""
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_very_long_output(self, mock_run):
         """Test handling of very long output from subprocess."""
         long_output = "A" * 10000 + " OK " + "B" * 10000
@@ -200,7 +204,7 @@ class TestVSCodeTestUtilsEdgeCases:
         assert "OK" in result.stdout
         assert len(result.stdout) == 20005  # 10000 + 4 (" OK ") + 10000 + 1
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_unicode_characters_in_output(self, mock_run):
         """Test handling of unicode characters in subprocess output."""
         mock_result = Mock()
@@ -221,7 +225,7 @@ class TestVSCodeTestUtilsEdgeCases:
 @pytest.fixture
 def temp_js_file():
     """Fixture to create temporary JavaScript test file."""
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.js', delete=False) as f:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".js", delete=False) as f:
         f.write('console.log("Test OK");')
         temp_path = f.name
 
@@ -239,17 +243,22 @@ def test_vscode_parse_ndjson_with_temp_file(temp_js_file):
     assert "OK" in result.stdout
 
 
-@pytest.mark.parametrize("return_code,stdout,stderr,should_have_ok", [
-    (0, "Test passed OK", "", True),
-    (0, "Test passed ok", "", False),  # Case sensitive
-    (0, "EVERYTHING IS OK", "", True),
-    (1, "Test failed OK", "Error occurred", True),  # OK in stdout even with failure
-    (0, "", "", False),  # Empty output
-    (0, "No success marker", "", False),
-    (127, "Command not found", "", False),
-])
-@patch('subprocess.run')
-def test_vscode_parse_ndjson_parametrized(mock_run, return_code, stdout, stderr, should_have_ok):
+@pytest.mark.parametrize(
+    "return_code,stdout,stderr,should_have_ok",
+    [
+        (0, "Test passed OK", "", True),
+        (0, "Test passed ok", "", False),  # Case sensitive
+        (0, "EVERYTHING IS OK", "", True),
+        (1, "Test failed OK", "Error occurred", True),  # OK in stdout even with failure
+        (0, "", "", False),  # Empty output
+        (0, "No success marker", "", False),
+        (127, "Command not found", "", False),
+    ],
+)
+@patch("subprocess.run")
+def test_vscode_parse_ndjson_parametrized(
+    mock_run, return_code, stdout, stderr, should_have_ok
+):
     """Parametrized test for various subprocess outcomes."""
     mock_result = Mock()
     mock_result.returncode = return_code


### PR DESCRIPTION
## Summary
- clean up stray diff markers in `pyrightconfig.json`
- remove f-string warnings in validation and tests
- tweak dummy fixtures to satisfy ruff
- add simple identifier validator for security test

## Testing
- `ruff check tests/unit/services/test_llm.py tests/unit/test_app_setup.py tests/unit/test_vscode_utils.py tests/unit/config/test_config_validation.py tests/integration/api/test_stdio_mcp.py tests/integration/api/test_mcp_inspector.py`
- `ruff check .`
- `poetry run mypy src/`
- `poetry run pyright src/`
- `poetry run pytest -q` *(tests disabled)*

------
https://chatgpt.com/codex/tasks/task_e_685b5bf2c230832a91f2ef693a45b46b